### PR TITLE
Add criteria to decide from where to take timestamp and trigger valeus

### DIFF
--- a/ctapipe_io_lst/__init__.py
+++ b/ctapipe_io_lst/__init__.py
@@ -8,8 +8,9 @@ import numpy as np
 import struct
 from astropy import units as u
 import os
-from os import listdir, getcwd
-
+from os import listdir
+from astropy.time import Time
+from datetime import datetime
 from ctapipe.core import Provenance
 from ctapipe.instrument import (
     TelescopeDescription,
@@ -232,26 +233,71 @@ class LSTEventSource(EventSource):
         event_container.module_status = event.lstcam.module_status
         event_container.extdevices_presence = event.lstcam.extdevices_presence
 
-        # unpack TIB data
-        rec_fmt = '=IHIBB'
-        unpacked_tib = struct.unpack(rec_fmt, event.lstcam.tib_data)
-        event_container.tib_event_counter = unpacked_tib[0]
-        event_container.tib_pps_counter = unpacked_tib[1]
-        event_container.tib_tenMHz_counter = unpacked_tib[2]
-        event_container.tib_stereo_pattern = unpacked_tib[3]
-        event_container.tib_masked_trigger = unpacked_tib[4]
-        event_container.swat_data = event.lstcam.swat_data
+        # if TIB data are there
+        if event_container.extdevices_presence & 1:
+            # unpack TIB data
+            rec_fmt = '=IHIBB'
+            unpacked_tib = struct.unpack(rec_fmt, event.lstcam.tib_data)
+            event_container.tib_event_counter = unpacked_tib[0]
+            event_container.tib_pps_counter = unpacked_tib[1]
+            event_container.tib_tenMHz_counter = unpacked_tib[2]
+            event_container.tib_stereo_pattern = unpacked_tib[3]
+            event_container.tib_masked_trigger = unpacked_tib[4]
+        else:
+            # missing TIB data
+            event_container.tib_event_counter = -1
+            event_container.tib_pps_counter = -1
+            event_container.tib_tenMHz_counter = -1
+            event_container.tib_stereo_pattern = -1
+            event_container.tib_masked_trigger = -1
 
-        # unpack CDTS data
-        rec_fmt = '=IIIQQBBB'
-        unpacked_cdts =  struct.unpack(rec_fmt, event.lstcam.cdts_data)
-        event_container.ucts_event_counter = unpacked_cdts[0]
-        event_container.ucts_pps_counter = unpacked_cdts[1]
-        event_container.ucts_clock_counter = unpacked_cdts[2]
-        event_container.ucts_timestamp = unpacked_cdts[3]
-        event_container.ucts_camera_timestamp = unpacked_cdts[4]
-        event_container.ucts_trigger_type = unpacked_cdts[5]
-        event_container.ucts_white_rabbit_status = unpacked_cdts[6]
+        # if UCTS data are there
+        if event_container.extdevices_presence & 2:
+
+            # unpack UCTS-CDTS data
+            rec_fmt = '=IIIQQBBB'
+            unpacked_cdts =  struct.unpack(rec_fmt, event.lstcam.cdts_data)
+            event_container.ucts_event_counter = unpacked_cdts[0]
+            event_container.ucts_pps_counter = unpacked_cdts[1]
+            event_container.ucts_clock_counter = unpacked_cdts[2]
+            event_container.ucts_timestamp = unpacked_cdts[3]
+            event_container.ucts_camera_timestamp = unpacked_cdts[4]
+            event_container.ucts_trigger_type = unpacked_cdts[5]
+            event_container.ucts_white_rabbit_status = unpacked_cdts[6]
+
+        else:
+            event_container.ucts_event_counter = -1
+            event_container.ucts_pps_counter = -1
+            event_container.ucts_clock_counter = -1
+            event_container.ucts_timestamp = -1
+            event_container.ucts_camera_timestamp = -1
+            event_container.ucts_trigger_type = -1
+            event_container.ucts_white_rabbit_status = -1
+
+
+        # if SWAT data are there
+        if event_container.extdevices_presence & 4:
+            # unpack SWAT data
+            rec_fmt = '=QIIBBIBI'
+            unpacked_swat = struct.unpack(rec_fmt, event.lstcam.swat_data)
+            event_container.swat_timestamp = unpacked_swat[0]
+            event_container.swat_counter1 = unpacked_swat[1]
+            event_container.swat_counter2 = unpacked_swat[2]
+            event_container.swat_event_type = unpacked_swat[3]
+            event_container.swat_camera_flag = unpacked_swat[4]
+            event_container.swat_camera_event_num = unpacked_swat[5]
+            event_container.swat_array_flag = unpacked_swat[6]
+            event_container.swat_array_event_num = unpacked_swat[7]
+
+        else:
+            event_container.swat_timestamp =-1
+            event_container.swat_counter1 = -1
+            event_container.swat_counter2 = -1
+            event_container.swat_event_type = -1
+            event_container.swat_camera_flag = -1
+            event_container.swat_camera_event_num = -1
+            event_container.swat_array_flag = -1
+            event_container.swat_array_event_num = -1
 
         # unpack Dragon counters
         rec_fmt = '=HIIIQ'
@@ -281,19 +327,27 @@ class LSTEventSource(EventSource):
     def fill_r0_camera_container_from_zfile(self, r0_container, event):
         """
         Fill with R0CameraContainer
-
         """
 
+        # look for correct trigger_time (TAI time in ns), first in UCTS and then in TIB
 
-        # temporary patch to have an event time set
-        r0_container.trigger_time = (
-            self.data.lst.tel[self.camera_config.telescope_id].evt.tib_pps_counter +
-            self.data.lst.tel[self.camera_config.telescope_id].evt.tib_tenMHz_counter * 10**(-7))
+        if self.data.lst.tel[self.camera_config.telescope_id].evt.ucts_timestamp > 0:
+            r0_container.trigger_time = self.data.lst.tel[self.camera_config.telescope_id].evt.ucts_timestamp
 
-        if r0_container.trigger_time is None:
+        elif self.data.lst.tel[self.camera_config.telescope_id].evt.tib_pps_counter >0:
+            r0_container.trigger_time = (
+                self.data.lst.tel[self.camera_config.telescope_id].evt.tib_pps_counter +
+                self.data.lst.tel[self.camera_config.telescope_id].evt.tib_tenMHz_counter * 10**(-7))
+        else:
             r0_container.trigger_time = 0
-        #r0_container.trigger_type = event.trigger_type
-        r0_container.trigger_type = self.data.lst.tel[self.camera_config.telescope_id].evt.tib_masked_trigger
+
+        # look for correct trigger type first in UCTS and then in TIB
+        if self.data.lst.tel[self.camera_config.telescope_id].evt.ucts_trigger_type > 0:
+            r0_container.trigger_type = self.data.lst.tel[self.camera_config.telescope_id].evt.ucts_trigger_type
+        elif self.data.lst.tel[self.camera_config.telescope_id].evt.tib_masked_trigger > 0:
+            r0_container.trigger_type = self.data.lst.tel[self.camera_config.telescope_id].evt.tib_masked_trigger
+        else:
+            r0_container.trigger_type = -1
 
         # verify the number of gains
         if event.waveform.shape[0] != self.camera_config.num_pixels * self.camera_config.num_samples * self.n_gains:

--- a/ctapipe_io_lst/__init__.py
+++ b/ctapipe_io_lst/__init__.py
@@ -329,13 +329,13 @@ class LSTEventSource(EventSource):
         Fill with R0CameraContainer
         """
 
-        # look for correct trigger_time (TAI time in ns), first in UCTS and then in TIB
-
+        # look for correct trigger_time (TAI time in s), first in UCTS and then in TIB
         if self.data.lst.tel[self.camera_config.telescope_id].evt.ucts_timestamp > 0:
-            r0_container.trigger_time = self.data.lst.tel[self.camera_config.telescope_id].evt.ucts_timestamp
+            r0_container.trigger_time = self.data.lst.tel[self.camera_config.telescope_id].evt.ucts_timestamp/1e9
 
-        elif self.data.lst.tel[self.camera_config.telescope_id].evt.tib_pps_counter >0:
+        elif self.data.lst.tel[self.camera_config.telescope_id].evt.tib_pps_counter > 0:
             r0_container.trigger_time = (
+                self.data.lst.tel[self.camera_config.telescope_id].svc.date +
                 self.data.lst.tel[self.camera_config.telescope_id].evt.tib_pps_counter +
                 self.data.lst.tel[self.camera_config.telescope_id].evt.tib_tenMHz_counter * 10**(-7))
         else:

--- a/ctapipe_io_lst/__init__.py
+++ b/ctapipe_io_lst/__init__.py
@@ -330,10 +330,11 @@ class LSTEventSource(EventSource):
         """
 
         # look for correct trigger_time (TAI time in s), first in UCTS and then in TIB
-        if self.data.lst.tel[self.camera_config.telescope_id].evt.ucts_timestamp > 0:
-            r0_container.trigger_time = self.data.lst.tel[self.camera_config.telescope_id].evt.ucts_timestamp/1e9
+        #if self.data.lst.tel[self.camera_config.telescope_id].evt.ucts_timestamp > 0:
+        #    r0_container.trigger_time = self.data.lst.tel[self.camera_config.telescope_id].evt.ucts_timestamp/1e9
 
-        elif self.data.lst.tel[self.camera_config.telescope_id].evt.tib_pps_counter > 0:
+        # consider for the moment only TIB time since UCTS seems not correct
+        if self.data.lst.tel[self.camera_config.telescope_id].evt.tib_pps_counter > 0:
             r0_container.trigger_time = (
                 self.data.lst.tel[self.camera_config.telescope_id].svc.date +
                 self.data.lst.tel[self.camera_config.telescope_id].evt.tib_pps_counter +
@@ -342,9 +343,11 @@ class LSTEventSource(EventSource):
             r0_container.trigger_time = 0
 
         # look for correct trigger type first in UCTS and then in TIB
-        if self.data.lst.tel[self.camera_config.telescope_id].evt.ucts_trigger_type > 0:
-            r0_container.trigger_type = self.data.lst.tel[self.camera_config.telescope_id].evt.ucts_trigger_type
-        elif self.data.lst.tel[self.camera_config.telescope_id].evt.tib_masked_trigger > 0:
+        #if self.data.lst.tel[self.camera_config.telescope_id].evt.ucts_trigger_type > 0:
+        #    r0_container.trigger_type = self.data.lst.tel[self.camera_config.telescope_id].evt.ucts_trigger_type
+
+        # consider for the moment only TIB trigger since UCTS seems not correct
+        if self.data.lst.tel[self.camera_config.telescope_id].evt.tib_masked_trigger > 0:
             r0_container.trigger_type = self.data.lst.tel[self.camera_config.telescope_id].evt.tib_masked_trigger
         else:
             r0_container.trigger_type = -1

--- a/ctapipe_io_lst/containers.py
+++ b/ctapipe_io_lst/containers.py
@@ -88,8 +88,14 @@ class LSTEventContainer(Container):
     ucts_trigger_type = Field(None, "UCTS trigger type")
     ucts_white_rabbit_status = Field(None, "UCTS whiteRabbit status")
 
-    #cdts_data = Field([], "CDTS data array")
-    swat_data = Field([], "SWAT data array")
+    swat_timestamp = Field(None, "SWAT timestamp")
+    swat_counter1 = Field(None, "SWAT event counter 1")
+    swat_counter2 = Field(None, "SWAT event counter 2")
+    swat_event_type = Field(None, "SWAT event type")
+    swat_camera_flag = Field(None, "SWAT camera flag ")
+    swat_camera_event_num = Field(None, "SWAT camera event number")
+    swat_array_flag = Field(None, "SWAT array negative flag")
+    swat_array_event_num = Field(None, "SWAT array event number")
 
     pps_counter= Field([], "Dragon pulse per second counter (n_modules)")
     tenMHz_counter = Field([], "Dragon 10 MHz counter (n_modules)")


### PR DESCRIPTION
In this PR I add the check of the flag that extdevices_presence flag (discovered only recently) that tells which devices are seen by the EvB. The R0  time and trigger are set with the following criteria: if UTCS is available its values are taken, otherwise the TIB values.

The timestamp is for the moment in ns (is it ok?)

I add also the unpacking go the SWAT data, even if they are empty of the moment.
