### PR TITLE
Fix pip install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .pytest_cache
+ctapipe_io_lst/_version_cache.py
 
 # Compiled files
 *.py[co]

--- a/ctapipe_io_lst/__init__.py
+++ b/ctapipe_io_lst/__init__.py
@@ -22,13 +22,15 @@ from ctapipe.instrument import (
 
 from ctapipe.io import EventSource
 from ctapipe.core.traits import Int, Bool
-from .containers import LSTDataContainer
 from ctapipe.io.containers import PixelStatusContainer
 
-from . import version
-__version__ = version.get_version(pep440=False)
+from .containers import LSTDataContainer
+from .version import get_version
 
+__version__ = get_version(pep440=False)
+print(__version__)
 __all__ = ['LSTEventSource']
+
 
 def load_camera_geometry(version=3):
     ''' Load camera geometry from bundled resources of this repo '''

--- a/ctapipe_io_lst/__init__.py
+++ b/ctapipe_io_lst/__init__.py
@@ -1,8 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 EventSource for LSTCam protobuf-fits.fz-files.
-
-Needs protozfits v1.4.2 from github.com/cta-sst-1m/protozfitsreader
 """
 import numpy as np
 import struct
@@ -28,8 +26,17 @@ from .containers import LSTDataContainer
 from .version import get_version
 
 __version__ = get_version(pep440=False)
-print(__version__)
 __all__ = ['LSTEventSource']
+
+
+
+OPTICS = OpticsDescription(
+    'LST',
+    equivalent_focal_length=u.Quantity(28, u.m),
+    num_mirrors=1,
+    mirror_area=u.Quantity(386.73, u.m**2),
+    num_mirror_tiles=198,
+)
 
 
 def load_camera_geometry(version=3):
@@ -38,6 +45,7 @@ def load_camera_geometry(version=3):
         'ctapipe_io_lst', 'resources/LSTCam-{:03d}.camgeom.fits.gz'.format(version)
     )
     return CameraGeometry.from_table(f)
+
 
 
 class LSTEventSource(EventSource):
@@ -127,14 +135,11 @@ class LSTEventSource(EventSource):
 
         tel_id = 1
 
-        # optics info from standard optics.fits.gz file
-        optics = OpticsDescription.from_name("LST")
-
         # camera info from LSTCam-[geometry_version].camgeom.fits.gz file
         camera = load_camera_geometry(version=self.geometry_version)
 
         tel_descr = TelescopeDescription(
-            name='LST', tel_type='LST', optics=optics, camera=camera
+            name='LST', tel_type='LST', optics=OPTICS, camera=camera
         )
 
         tels = {tel_id: tel_descr}
@@ -162,14 +167,11 @@ class LSTEventSource(EventSource):
         # Instrument information
         for tel_id in self.data.lst.tels_with_data:
 
-            # optics info from standard optics.fits.gz file
-            optics = OpticsDescription.from_name("LST")
-
             # camera info from LSTCam-[geometry_version].camgeom.fits.gz file
             camera = load_camera_geometry(version=self.geometry_version)
 
             tel_descr = TelescopeDescription(
-                name='LST', tel_type='LST', optics=optics, camera=camera
+                name='LST', tel_type='LST', optics=OPTICS, camera=camera
             )
 
             self.n_camera_pixels = tel_descr.camera.n_pixels

--- a/ctapipe_io_lst/tests/test_version.py
+++ b/ctapipe_io_lst/tests/test_version.py
@@ -1,0 +1,4 @@
+def test_version():
+    from ctapipe_io_lst import __version__
+
+    assert __version__ != 'unknown'

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 from os import path
-import ctapipe_io_lst
+from version import get_version, update_release_version
 
 # read the contents of your README file
 this_directory = path.abspath(path.dirname(__file__))
@@ -8,17 +8,21 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
+update_release_version()
+version = get_version()
+
 setup(
     name='ctapipe_io_lst',
     packages=find_packages(),
-    version=ctapipe_io_lst.__version__,
+    version=version,
     description='ctapipe plugin for reading LST prototype files',
     long_description=long_description,
     long_description_content_type='text/markdown',
     install_requires=[
         'astropy',
         'ctapipe',
-        'protozfits'
+        'protozfits @ https://github.com/cta-sst-1m/protozfitsreader/archive/v1.4.2.tar.gz',
+
     ],
     package_data={
         'ctapipe_io_lst': ['resources/*'],

--- a/version.py
+++ b/version.py
@@ -1,0 +1,171 @@
+"""
+Get version identification from git.
+
+
+The update_release_version() function writes the current version to the
+VERSION file. This function should be called before packaging a release version.
+
+Use the get_version() function to get the version string, including the latest
+commit,  from git.
+If git is not available the VERSION file will be read.
+
+Heres an example of such a version string:
+
+    v0.2.0.post58+git57440dc
+
+
+This script was taken from here:
+https://github.com/cta-observatory/ctapipe/blob/master/ctapipe/version.py
+
+but the original code comes from here: 
+https://github.com/aebrahim/python-git-version
+
+Combining ideas from
+http://blogs.nopcode.org/brainstorm/2013/05/20/pragmatic-python-versioning-via-setuptools-and-git-tags/
+and Python Versioneer
+https://github.com/warner/python-versioneer
+but being much more lightwheight
+
+"""
+from subprocess import check_output, CalledProcessError
+from os import path, name, devnull, environ, listdir
+
+__all__ = ("get_version",)
+
+CURRENT_DIRECTORY = path.dirname(path.abspath(__file__))
+VERSION_FILE = path.join(CURRENT_DIRECTORY, 'ctapipe_io_lst', "_version_cache.py")
+
+GIT_COMMAND = "git"
+
+if name == "nt":
+    def find_git_on_windows():
+        """find the path to the git executable on windows"""
+        # first see if git is in the path
+        try:
+            check_output(["where", "/Q", "git"])
+            # if this command succeeded, git is in the path
+            return "git"
+        # catch the exception thrown if git was not found
+        except CalledProcessError:
+            pass
+        # There are several locations git.exe may be hiding
+        possible_locations = []
+        # look in program files for msysgit
+        if "PROGRAMFILES(X86)" in environ:
+            possible_locations.append("%s/Git/cmd/git.exe" %
+                                      environ["PROGRAMFILES(X86)"])
+        if "PROGRAMFILES" in environ:
+            possible_locations.append("%s/Git/cmd/git.exe" %
+                                      environ["PROGRAMFILES"])
+        # look for the github version of git
+        if "LOCALAPPDATA" in environ:
+            github_dir = "%s/GitHub" % environ["LOCALAPPDATA"]
+            if path.isdir(github_dir):
+                for subdir in listdir(github_dir):
+                    if not subdir.startswith("PortableGit"):
+                        continue
+                    possible_locations.append("%s/%s/bin/git.exe" %
+                                              (github_dir, subdir))
+        for possible_location in possible_locations:
+            if path.isfile(possible_location):
+                return possible_location
+        # git was not found
+        return "git"
+
+    GIT_COMMAND = find_git_on_windows()
+
+
+def get_git_describe_version(abbrev=7):
+    """return the string output of git desribe"""
+    try:
+        with open(devnull, "w") as fnull:
+            arguments = [GIT_COMMAND, "describe", "--tags",
+                         "--abbrev=%d" % abbrev]
+            return check_output(arguments, cwd=CURRENT_DIRECTORY,
+                                stderr=fnull).decode("ascii").strip()
+    except (OSError, CalledProcessError):
+        return None
+
+
+def format_git_describe(git_str, pep440=False):
+    """format the result of calling 'git describe' as a python version"""
+
+    if "-" not in git_str:  # currently at a tag
+        formatted_str = git_str
+    else:
+        # formatted as version-N-githash
+        # want to convert to version.postN-githash
+        git_str = git_str.replace("-", ".post", 1)
+        if pep440:  # does not allow git hash afterwards
+            formatted_str = git_str.split("-")[0]
+        else:
+            formatted_str = git_str.replace("-g", "+git")
+
+    # need to remove the "v" to have a proper python version
+    if formatted_str.startswith('v'):
+        formatted_str = formatted_str[1:]
+
+    return formatted_str
+
+
+def read_release_version():
+    """Read version information from VERSION file"""
+    try:
+        from ._version_cache import version
+        if len(version) == 0:
+            version = None
+        return version
+    except ImportError:
+        return "unknown"
+
+
+def update_release_version(pep440=False):
+    """Release versions are stored in a file called VERSION.
+    This method updates the version stored in the file.
+    This function should be called when creating new releases.
+    It is called by setup.py when building a package.
+
+
+    pep440: bool
+        When True, this function returns a version string suitable for
+        a release as defined by PEP 440. When False, the githash (if
+        available) will be appended to the version string.
+
+    """
+    version = get_version(pep440=pep440)
+    print('writing version to', VERSION_FILE)
+    with open(VERSION_FILE, "w") as outfile:
+        outfile.write(f"version='{version}'")
+        outfile.write("\n")
+
+
+def get_version(pep440=False):
+    """Tracks the version number.
+
+    pep440: bool
+        When True, this function returns a version string suitable for
+        a release as defined by PEP 440. When False, the githash (if
+        available) will be appended to the version string.
+
+    The file VERSION holds the version information. If this is not a git
+    repository, then it is reasonable to assume that the version is not
+    being incremented and the version returned will be the release version as
+    read from the file.
+
+    However, if the script is located within an active git repository,
+    git-describe is used to get the version information.
+
+    The file VERSION will need to be changed manually.
+    """
+
+    raw_git_version = get_git_describe_version()
+    if not raw_git_version:  # not a git repository
+        return  read_release_version()
+
+    git_version = format_git_describe(raw_git_version, pep440=pep440)
+
+    return git_version
+
+
+if __name__ == "__main__":
+    print(get_version())


### PR DESCRIPTION
* Add link to prozozfits reader (there is a newer version, do you want to still use 1.4.2?)
* Duplicate version.py so it can be used at runtime and at install time (a bit ugly, but works)
* Define OPTICS  instead of using `OpticsDescription.from_name`, so this works without ctapipe-extra