### PR TITLE
Changes for calibration tools

### DIFF
--- a/ctapipe_io_lst/__init__.py
+++ b/ctapipe_io_lst/__init__.py
@@ -329,8 +329,8 @@ class LSTEventSource(EventSource):
             self.tag_flatfield_events(array_event)
 
             # gain select and calibrate to pe
-            #if self.r0_r1_calibrator.calibration_path is not None:
-            #    self.r0_r1_calibrator.calibrate(array_event)
+            if self.r0_r1_calibrator.calibration_path is not None:
+                self.r0_r1_calibrator.calibrate(array_event)
 
             yield array_event
 

--- a/ctapipe_io_lst/__init__.py
+++ b/ctapipe_io_lst/__init__.py
@@ -35,7 +35,9 @@ from .anyarray_dtypes import (
     DRAGON_COUNTERS_DTYPE,
     TIB_DTYPE,
 )
-
+from .constants import (
+    HIGH_GAIN
+)
 
 __version__ = get_version(pep440=False)
 __all__ = ['LSTEventSource']
@@ -136,20 +138,20 @@ class LSTEventSource(EventSource):
         help='Read in parallel all streams '
     ).tag(config=True)
 
-    min_flatfield_pe = Float(
-        default_value=50,
+    min_flatfield_adc = Float(
+        default_value=4000.0,
         help=(
             'Events with that have more than ``min_flatfield_pixel_fraction``'
-            ' of the pixels inside [``min_flatfield_pe``, ``max_flatfield_pe``]'
+            ' of the pixels inside [``min_flatfield_adc``, ``max_flatfield_adc``]'
             ' get tagged as EventType.FLATFIELD'
         ),
     ).tag(config=True)
 
-    max_flatfield_pe = Float(
-        default_value=110.0,
+    max_flatfield_adc = Float(
+        default_value=12000.0,
         help=(
             'Events with that have more than ``min_flatfield_pixel_fraction``'
-            ' of the pixels inside [``min_flatfield_pe``, ``max_flatfield_pe``]'
+            ' of the pixels inside [``min_flatfield_adc``, ``max_flatfield_adc``]'
             ' get tagged as EventType.FLATFIELD'
         ),
     ).tag(config=True)
@@ -319,11 +321,16 @@ class LSTEventSource(EventSource):
             self.fill_mon_container(array_event, zfits_event)
             self.fill_pointing_info(array_event)
 
+            # apply low level corrections
             if self.r0_r1_calibrator.drs4_pedestal_path.tel[self.tel_id] is not None:
-                self.r0_r1_calibrator.calibrate(array_event)
+                self.r0_r1_calibrator.drs4_correct(array_event)
 
-                # tagging flat field events needs r1
-                self.tag_flatfield_events(array_event)
+            # tagging flat field events
+            self.tag_flatfield_events(array_event)
+
+            # gain select and calibrate to pe
+            #if self.r0_r1_calibrator.calibration_path is not None:
+            #    self.r0_r1_calibrator.calibrate(array_event)
 
             yield array_event
 
@@ -495,8 +502,8 @@ class LSTEventSource(EventSource):
             return
 
         tel_id = self.tel_id
-        image = array_event.r1.tel[tel_id].waveform.sum(axis=1)
-        in_range = (image >= self.min_flatfield_pe) & (image <= self.max_flatfield_pe)
+        image = array_event.r1.tel[tel_id].waveform[HIGH_GAIN].sum(axis=1)
+        in_range = (image >= self.min_flatfield_adc) & (image <= self.max_flatfield_adc)
 
         if np.count_nonzero(in_range) >= self.min_flatfield_pixel_fraction * image.size:
             self.log.debug(

--- a/ctapipe_io_lst/calibration.py
+++ b/ctapipe_io_lst/calibration.py
@@ -176,7 +176,7 @@ class LSTR0Corrections(TelescopeComponent):
         if self.calibration_path is not None:
             self.mon_data = self._read_calibration_file(self.calibration_path)
 
-    def calibrate(self, event: ArrayEventContainer):
+    def drs4_correct(self, event: ArrayEventContainer):
         for tel_id in event.r0.tel:
             r1 = event.r1.tel[tel_id]
 
@@ -199,6 +199,11 @@ class LSTR0Corrections(TelescopeComponent):
             waveform = r1.waveform
 
             waveform -= self.offset.tel[tel_id]
+
+    def calibrate(self, event: ArrayEventContainer):
+        for tel_id in event.r0.tel:
+            r1 = event.r1.tel[tel_id]
+            waveform = r1.waveform
 
             # do gain selection before converting to pe
             # like eventbuilder will do


### PR DESCRIPTION
In order to use the new reader with the calibration tools it is useful to separate  low-level calibration from the high level (not used in the calibration tools) and to tag the flat-field events before the pe calibration.

