### PR TITLE
Fix for lstchain#559

### DIFF
--- a/ctapipe_io_lst/calibration.py
+++ b/ctapipe_io_lst/calibration.py
@@ -628,11 +628,8 @@ def do_time_lapse_corr(
                         start = first_capacitor + N_CAPACITORS_CHANNEL
                         end = start + 12
 
-                        # FIXME This reproduces bug cta-observatory/cta-lstchain#559
-                        # corrected version commented below.
-                        last_readout_time[gain, pixel_id, (start % N_CAPACITORS_PIXEL) : (end % N_CAPACITORS_PIXEL)] = time_now
-                        # for capacitor in range(start, end):
-                        #     last_readout_time[gain, pixel_id, capacitor % N_CAPACITORS_PIXEL] = time_now
+                        for capacitor in range(start, end):
+                            last_readout_time[gain, pixel_id, capacitor % N_CAPACITORS_PIXEL] = time_now
 
                     elif first_capacitor_in_channel >= 1013:
                         start = first_capacitor + N_CAPACITORS_CHANNEL


### PR DESCRIPTION
This fixes the bug discussed here: https://github.com/cta-observatory/cta-lstchain/issues/559

Before and after comparison:

![charge_comparison_now](https://user-images.githubusercontent.com/5488440/106144884-22551000-6175-11eb-893e-b1c63efe98b4.png)

