### PR TITLE
Use tib trigger if available by default

### DIFF
--- a/ctapipe_io_lst/__init__.py
+++ b/ctapipe_io_lst/__init__.py
@@ -477,7 +477,19 @@ class LSTEventSource(EventSource):
         trigger.tels_with_trigger = [tel_id]
         trigger.tel[tel_id].time = trigger.time
 
-        trigger_bits = array_event.lst.tel[tel_id].evt.ucts_trigger_type
+        lst = array_event.lst.tel[tel_id]
+        tib_available = lst.evt.extdevices_presence & 1
+
+        # tib seems to be more reliable when available
+        if tib_available:
+            trigger_bits = lst.evt.tib_masked_trigger
+
+        else:
+            trigger_bits = lst.evt.ucts_trigger_type
+
+        if lst.evt.ucts_trigger_type == 42:
+            self.log.warning('Event with UCTS trigger_type 42 found. Probably means unreliable or shifted UCTS data.')
+
         # first bit mono trigger, second stereo.
         # If *only* those two are set, we assume it's a physics event
         # for all other we only check if the flag is present

--- a/ctapipe_io_lst/__init__.py
+++ b/ctapipe_io_lst/__init__.py
@@ -169,7 +169,7 @@ class LSTEventSource(EventSource):
         help=(
             'Default source for trigger type information.'
             ' For older data, tib might be the better choice but for data newer'
-            ' than 2020-07, ucts is the preferred option. The source will still'
+            ' than 2020-06-25, ucts is the preferred option. The source will still'
             ' fallback to the other device if the chosen default device is not '
             ' available'
         )
@@ -515,7 +515,7 @@ class LSTEventSource(EventSource):
             self.log.warning(
                 'Event with UCTS trigger_type 42 found.'
                 ' Probably means unreliable or shifted UCTS data.'
-                ' Switching to TIB if available.'
+                ' Consider switching to TIB using `default_trigger_type="tib"`'
             )
 
         # first bit mono trigger, second stereo.

--- a/ctapipe_io_lst/__init__.py
+++ b/ctapipe_io_lst/__init__.py
@@ -479,16 +479,21 @@ class LSTEventSource(EventSource):
 
         lst = array_event.lst.tel[tel_id]
         tib_available = lst.evt.extdevices_presence & 1
+        ucts_available = lst.evt.extdevices_presence & 2
 
         # tib seems to be more reliable when available
         if tib_available:
             trigger_bits = lst.evt.tib_masked_trigger
-
-        else:
+        elif ucts_available:
             trigger_bits = lst.evt.ucts_trigger_type
-
-        if lst.evt.ucts_trigger_type == 42:
-            self.log.warning('Event with UCTS trigger_type 42 found. Probably means unreliable or shifted UCTS data.')
+            if lst.evt.ucts_trigger_type == 42:
+                self.log.warning(
+                    'Event with UCTS trigger_type 42 found.'
+                    ' Probably means unreliable or shifted UCTS data.'
+                )
+        else:
+            self.log.warning('No trigger info available.')
+            return
 
         # first bit mono trigger, second stereo.
         # If *only* those two are set, we assume it's a physics event

--- a/ctapipe_io_lst/tests/test_stage1.py
+++ b/ctapipe_io_lst/tests/test_stage1.py
@@ -43,7 +43,7 @@ def test_stage1(tmpdir):
                 'dragon_counter0': int(run_info['dragon_counter0']),
                 'ucts_t0_tib': int(run_info['ucts_t0_tib']),
                 'tib_counter0': int(run_info['tib_counter0']),
-            }
+            },
         },
         "CameraCalibrator": {
             "image_extractor_type": "LocalPeakWindowSum",
@@ -86,6 +86,5 @@ def test_stage1(tmpdir):
     # one pedestal and flat field expected each, rest should be physics data
     assert event_type_counts.sum() == 200
     assert event_type_counts[EventType.FLATFIELD.value] == 1
-    assert event_type_counts[EventType.SKY_PEDESTAL.value] == 2
-    assert event_type_counts[EventType.SUBARRAY.value] == 197
-    assert tool.event_source.ucts_42_found
+    assert event_type_counts[EventType.SKY_PEDESTAL.value] == 1
+    assert event_type_counts[EventType.SUBARRAY.value] == 198

--- a/ctapipe_io_lst/tests/test_stage1.py
+++ b/ctapipe_io_lst/tests/test_stage1.py
@@ -86,5 +86,6 @@ def test_stage1(tmpdir):
     # one pedestal and flat field expected each, rest should be physics data
     assert event_type_counts.sum() == 200
     assert event_type_counts[EventType.FLATFIELD.value] == 1
-    assert event_type_counts[EventType.SKY_PEDESTAL.value] == 1
-    assert event_type_counts[EventType.SUBARRAY.value] == 198
+    assert event_type_counts[EventType.SKY_PEDESTAL.value] == 2
+    assert event_type_counts[EventType.SUBARRAY.value] == 197
+    assert tool.event_source.ucts_42_found


### PR DESCRIPTION
This is motivated by run 2006.0000, where after a UCTS trigger type
with value 42 the ucts trigger type seems to be shifted by one
without the UCTS time showing an offset.

Also adds  a warning if an event with UCTS trigger == 42 is encountered.