### PR TITLE
Changes for interleaved events and old runs

### DIFF
--- a/ctapipe_io_lst/__init__.py
+++ b/ctapipe_io_lst/__init__.py
@@ -175,6 +175,11 @@ class LSTEventSource(EventSource):
         )
     ).tag(config=True)
 
+    calibrate_flatfields_and_pedestals = Bool(
+        default_value=True,
+        help='To be set to True for calibration processing'
+    ).tag(config=True)
+
     classes = [PointingSource, EventTimeCalculator, LSTR0Corrections]
 
     def __init__(self, input_url=None, **kwargs):
@@ -341,7 +346,13 @@ class LSTEventSource(EventSource):
 
             # gain select and calibrate to pe
             if self.r0_r1_calibrator.calibration_path is not None:
-                self.r0_r1_calibrator.calibrate(array_event)
+
+                # skip flatfield and pedestal events if asked
+                if (not (array_event.trigger.event_type == EventType.FLATFIELD or
+                    array_event.trigger.event_type == EventType.SKY_PEDESTAL) or
+                         self.calibrate_flatfields_and_pedestals):
+
+                    self.r0_r1_calibrator.calibrate(array_event)
 
             yield array_event
 

--- a/ctapipe_io_lst/__init__.py
+++ b/ctapipe_io_lst/__init__.py
@@ -348,10 +348,10 @@ class LSTEventSource(EventSource):
             if self.r0_r1_calibrator.calibration_path is not None:
 
                 # skip flatfield and pedestal events if asked
-                if (not (array_event.trigger.event_type == EventType.FLATFIELD or
-                    array_event.trigger.event_type == EventType.SKY_PEDESTAL) or
-                         self.calibrate_flatfields_and_pedestals):
-
+                if (
+                    array_event.trigger.event_type not in {EventType.FLATFIELD, EventType.SKY_PEDESTAL}
+                        or self.calibrate_flatfields_and_pedestals
+                ):
                     self.r0_r1_calibrator.calibrate(array_event)
 
             yield array_event

--- a/ctapipe_io_lst/__init__.py
+++ b/ctapipe_io_lst/__init__.py
@@ -6,6 +6,7 @@ import numpy as np
 from astropy import units as u
 from pkg_resources import resource_filename
 import os
+from astropy.time import Time
 from os import listdir
 from ctapipe.core import Provenance
 from ctapipe.instrument import (
@@ -178,6 +179,11 @@ class LSTEventSource(EventSource):
     calibrate_flatfields_and_pedestals = Bool(
         default_value=True,
         help='To be set to True for calibration processing'
+    ).tag(config=True)
+
+    fill_timestamp = Bool(
+        default_value=True,
+        help='To be set to False for data without ucts info'
     ).tag(config=True)
 
     classes = [PointingSource, EventTimeCalculator, LSTR0Corrections]
@@ -495,7 +501,10 @@ class LSTEventSource(EventSource):
         tel_id = self.tel_id
 
         trigger = array_event.trigger
-        trigger.time = self.time_calculator(tel_id, array_event)
+        if self.fill_timestamp:
+            trigger.time = self.time_calculator(tel_id, array_event)
+        else:
+            trigger.time = Time(0, format='mjd', scale='tai')
         trigger.tels_with_trigger = [tel_id]
         trigger.tel[tel_id].time = trigger.time
 

--- a/ctapipe_io_lst/calibration.py
+++ b/ctapipe_io_lst/calibration.py
@@ -136,11 +136,6 @@ class LSTR0Corrections(TelescopeComponent):
         help='Threshold for the ThresholdGainSelector.'
     ).tag(config=True)
 
-    calibrate_ff_and_ped = Bool(
-        default_value=True,
-        help=('To be set to True for calibration processing')
-    ).tag(config=True)
-
     def __init__(self, subarray, config=None, parent=None, **kwargs):
         """
         The R0 calibrator for LST data.
@@ -210,12 +205,6 @@ class LSTR0Corrections(TelescopeComponent):
             )
 
     def calibrate(self, event: ArrayEventContainer):
-
-        if ((event.trigger.event_type == EventType.FLATFIELD or
-             event.trigger.event_type == EventType.SKY_PEDESTAL) and
-            not self.calibrate_ff_and_ped):
-            return
-
 
         for tel_id in event.r0.tel:
             r1 = event.r1.tel[tel_id]

--- a/ctapipe_io_lst/event_time.py
+++ b/ctapipe_io_lst/event_time.py
@@ -180,7 +180,7 @@ class EventTimeCalculator(TelescopeComponent):
 
         # first event and values not passed
         else:
-            if not ucts_available:
+            if not ucts_available and self.timestamp == 'ucts':
                 raise ValueError(
                     'Timestamp reference should be extracted from first event'
                     ' but UCTS not available'

--- a/ctapipe_io_lst/event_time.py
+++ b/ctapipe_io_lst/event_time.py
@@ -180,7 +180,7 @@ class EventTimeCalculator(TelescopeComponent):
 
         # first event and values not passed
         else:
-            if not ucts_available and self.timestamp == 'ucts':
+            if not ucts_available:
                 raise ValueError(
                     'Timestamp reference should be extracted from first event'
                     ' but UCTS not available'


### PR DESCRIPTION
- Add trailet in order not to calibrate pedestals and FF events if requested
- Correct "if"  statement  for exception in case of missing ucts info, which is often the case in old runs