### PR TITLE
Make sure dtype of night summary table is int for counters

### DIFF
--- a/ctapipe_io_lst/event_time.py
+++ b/ctapipe_io_lst/event_time.py
@@ -4,7 +4,6 @@ import numpy as np
 import astropy.version
 from astropy.io.ascii import convert_numpy
 from astropy.table import Table
-from astropy.table import Table
 from astropy.time import Time, TimeUnixTai, TimeFromEpoch
 
 from ctapipe.core import TelescopeComponent


### PR DESCRIPTION
Columns will always have integer dtype where appropriate and where the fill contains `nan` these are converted to masked array elements.