### PR TITLE
Remove option to calculate timestamp from TIB, allow using svc.date as reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7]
-        ctapipe-version: [v0.10.0]
+        ctapipe-version: [v0.10.4]
 
     steps:
       - uses: actions/checkout@v2

--- a/ctapipe_io_lst/__init__.py
+++ b/ctapipe_io_lst/__init__.py
@@ -27,7 +27,7 @@ from ctapipe.containers import PixelStatusContainer, EventType
 from .containers import LSTArrayEventContainer, LSTServiceContainer
 from .version import __version__
 from .calibration import LSTR0Corrections
-from .event_time import EventTimeCalculator
+from .event_time import EventTimeCalculator, INVALID_TIME
 from .pointing import PointingSource
 from .anyarray_dtypes import (
     CDTS_AFTER_37201_DTYPE,
@@ -504,7 +504,7 @@ class LSTEventSource(EventSource):
         if self.fill_timestamp:
             trigger.time = self.time_calculator(tel_id, array_event)
         else:
-            trigger.time = Time(0, format='mjd', scale='tai')
+            trigger.time = INVALID_TIME
         trigger.tels_with_trigger = [tel_id]
         trigger.tel[tel_id].time = trigger.time
 

--- a/ctapipe_io_lst/__init__.py
+++ b/ctapipe_io_lst/__init__.py
@@ -181,11 +181,6 @@ class LSTEventSource(EventSource):
         help='To be set to True for calibration processing'
     ).tag(config=True)
 
-    fill_timestamp = Bool(
-        default_value=True,
-        help='To be set to False for data without ucts info'
-    ).tag(config=True)
-
     classes = [PointingSource, EventTimeCalculator, LSTR0Corrections]
 
     def __init__(self, input_url=None, **kwargs):
@@ -501,10 +496,7 @@ class LSTEventSource(EventSource):
         tel_id = self.tel_id
 
         trigger = array_event.trigger
-        if self.fill_timestamp:
-            trigger.time = self.time_calculator(tel_id, array_event)
-        else:
-            trigger.time = NAN_TIME
+        trigger.time = self.time_calculator(tel_id, array_event)
         trigger.tels_with_trigger = [tel_id]
         trigger.tel[tel_id].time = trigger.time
 

--- a/ctapipe_io_lst/__init__.py
+++ b/ctapipe_io_lst/__init__.py
@@ -22,12 +22,12 @@ from enum import IntFlag, auto
 from ctapipe.io import EventSource
 from ctapipe.io.datalevels import DataLevel
 from ctapipe.core.traits import Int, Bool, Float, Enum
-from ctapipe.containers import PixelStatusContainer, EventType
+from ctapipe.containers import PixelStatusContainer, EventType, NAN_TIME
 
 from .containers import LSTArrayEventContainer, LSTServiceContainer
 from .version import __version__
 from .calibration import LSTR0Corrections
-from .event_time import EventTimeCalculator, INVALID_TIME
+from .event_time import EventTimeCalculator
 from .pointing import PointingSource
 from .anyarray_dtypes import (
     CDTS_AFTER_37201_DTYPE,
@@ -504,7 +504,7 @@ class LSTEventSource(EventSource):
         if self.fill_timestamp:
             trigger.time = self.time_calculator(tel_id, array_event)
         else:
-            trigger.time = INVALID_TIME
+            trigger.time = NAN_TIME
         trigger.tels_with_trigger = [tel_id]
         trigger.tel[tel_id].time = trigger.time
 

--- a/ctapipe_io_lst/event_time.py
+++ b/ctapipe_io_lst/event_time.py
@@ -280,7 +280,7 @@ class EventTimeCalculator(TelescopeComponent):
             self._has_dragon_reference[tel_id] = True
 
 
-        # Dragon/TIB timestamps based on a valid absolute reference UCTS timestamp
+        # Dragon timestamp based on the reference timestamp
         dragon_timestamp = calc_dragon_time(
             lst, module_index,
             reference_time=self._dragon_reference_time[tel_id],

--- a/ctapipe_io_lst/event_time.py
+++ b/ctapipe_io_lst/event_time.py
@@ -160,6 +160,11 @@ class EventTimeCalculator(TelescopeComponent):
     These might be good enough for interpolating pointing information but
     are only precise for relative time changes, i.e. not suitable for pulsar
     analysis or matching events with MAGIC.
+
+    Extracting the reference will only work reliably for the first subrun
+    for ucts.
+    Using svc.date is only possible for the first subrun and will raise an erorr
+    if the event id of the first event seen by the time calculator is not 1.
     '''
 
     timestamp = TelescopeParameter(

--- a/ctapipe_io_lst/event_time.py
+++ b/ctapipe_io_lst/event_time.py
@@ -168,7 +168,14 @@ class EventTimeCalculator(TelescopeComponent):
     '''
 
     timestamp = TelescopeParameter(
-        trait=Enum(['ucts', 'dragon']), default_value='dragon'
+        trait=Enum(['ucts', 'dragon']), default_value='dragon',
+        help=(
+            'Source of the timestamp. UCTS is simplest and most precise,'
+            ' unfortunately it is not yet reliable, instead the time is calculated'
+            ' by default using the relative dragon board counters with a reference'
+            ' pair of counter / time. See the `dragon_reference_time` and'
+            ' `dragon_reference_counter` traitlets'
+        )
     ).tag(config=True)
 
     dragon_reference_time = TelescopeParameter(

--- a/ctapipe_io_lst/event_time.py
+++ b/ctapipe_io_lst/event_time.py
@@ -204,7 +204,6 @@ class EventTimeCalculator(TelescopeComponent):
 
         ucts_timestamp = lst.evt.ucts_timestamp
         ucts_time = ucts_timestamp * 1e-9
-        dragon_time = np.nan
 
         # first event and values not passed
         if not self._has_dragon_reference[tel_id]:

--- a/ctapipe_io_lst/event_time.py
+++ b/ctapipe_io_lst/event_time.py
@@ -354,18 +354,20 @@ class EventTimeCalculator(TelescopeComponent):
                 )
                 lst.evt.ucts_trigger_type = 0
 
-        # Select the timestamps to be used for pointing interpolation
-        if self.timestamp.tel[tel_id] == "ucts":
-            timestamp = Time(ucts_time, format='unix_tai')
-
-        elif self.timestamp.tel[tel_id] == "dragon":
-            timestamp = Time(dragon_time, format='unix_tai')
-
-        elif self.timestamp.tel[tel_id] == "tib":
-            timestamp = Time(tib_time, format='unix_tai')
-        else:
-            raise ValueError('Unknown timestamp requested')
-
         self.log.debug(f'tib: {tib_time:.7f}, dragon: {dragon_time:.7f}, ucts: {ucts_time:.7f}')
 
-        return timestamp
+        # Select the timestamps to be used for pointing interpolation
+        if self.timestamp.tel[tel_id] == "dragon":
+            return Time(dragon_time, format='unix_tai')
+
+        if self.timestamp.tel[tel_id] == "ucts":
+            return Time(ucts_time, format='unix_tai')
+
+        if self.timestamp.tel[tel_id] == "tib":
+            if np.isnan(tib_time):
+                self.log.warning('Tib time not available, using dragon')
+                return Time(dragon_time, format='unix_tai')
+
+            return Time(tib_time, format='unix_tai')
+
+        raise ValueError('Unknown timestamp requested')

--- a/ctapipe_io_lst/event_time.py
+++ b/ctapipe_io_lst/event_time.py
@@ -124,6 +124,29 @@ class EventTimeCalculator(TelescopeComponent):
 
     Also keeps track of "UCTS jumps", where UCTS info goes missing for
     a certain event and all following info has to be shifted.
+
+
+    There are several sources of timing information in LST raw data.
+
+    Each dragon module has two high precision counters, which however only
+    give a relative time.
+    Same is true for the TIB.
+
+    The only precise absolute timestamp is the UCTS timestamp.
+    However, at least during the commissioning, UCTS was/is not reliable
+    enough to only use the UCTS timestamp.
+
+    Instead, we calculate an absolute timestamp by using one valid pair
+    of dragon counter / ucts timestamp and then use the relative time elapsed
+    from this reference using the dragon counter.
+
+    For runs where no such UCTS reference exists, for example because UCTS
+    was completely unavailable, we use the start of run timestamp from the
+    camera configuration.
+    This will however result in imprecises timestamps off by several seconds.
+    These might be good enough for interpolating pointing information but
+    are only precise for relative time changes, i.e. not suitable for pulsar
+    analysis or matching events with MAGIC.
     '''
 
     timestamp = TelescopeParameter(

--- a/ctapipe_io_lst/tests/test_calib.py
+++ b/ctapipe_io_lst/tests/test_calib.py
@@ -18,6 +18,8 @@ test_time_calib_path = test_data / 'real/calibration/20200218/v05/time_calibrati
 test_missing_module_path = test_data / 'real/R0/20210215/LST-1.1.Run03669.0000_first50.fits.fz'
 
 
+
+
 def test_get_first_capacitor():
     from ctapipe_io_lst import LSTEventSource
     from ctapipe_io_lst.calibration import (
@@ -93,8 +95,8 @@ def test_source_with_drs4_pedestal():
         'LSTEventSource': {
             'LSTR0Corrections': {
                 'drs4_pedestal_path': test_drs4_pedestal_path,
-            }
-        }
+            },
+        },
     })
 
     source = LSTEventSource(
@@ -116,8 +118,8 @@ def test_source_with_calibration():
             'LSTR0Corrections': {
                 'drs4_pedestal_path': test_drs4_pedestal_path,
                 'calibration_path': test_calib_path,
-            }
-        }
+            },
+        },
     })
 
     source = LSTEventSource(
@@ -140,8 +142,8 @@ def test_source_with_all():
                 'drs4_pedestal_path': test_drs4_pedestal_path,
                 'drs4_time_calibration_path': test_time_calib_path,
                 'calibration_path': test_calib_path,
-            }
-        }
+            },
+        },
     })
 
     source = LSTEventSource(
@@ -166,8 +168,8 @@ def test_missing_module():
                 'drs4_pedestal_path': test_drs4_pedestal_path,
                 'drs4_time_calibration_path': test_time_calib_path,
                 'calibration_path': test_calib_path,
-            }
-        }
+            },
+        },
     })
 
     source = LSTEventSource(
@@ -194,8 +196,8 @@ def test_no_gain_selection():
                 'drs4_time_calibration_path': test_time_calib_path,
                 'calibration_path': test_calib_path,
                 'select_gain': False,
-            }
-        }
+            },
+        },
     })
 
     source = LSTEventSource(
@@ -221,8 +223,8 @@ def test_no_gain_selection_no_drs4time_calib():
                 'drs4_pedestal_path': test_drs4_pedestal_path,
                 'calibration_path': test_calib_path,
                 'select_gain': False,
-            }
-        }
+            },
+        },
     })
 
     source = LSTEventSource(

--- a/ctapipe_io_lst/tests/test_calib.py
+++ b/ctapipe_io_lst/tests/test_calib.py
@@ -162,7 +162,6 @@ def test_missing_module():
 
     config = Config({
         'LSTEventSource': {
-            'fill_timestamp': False,  #  ucts not available
             'LSTR0Corrections': {
                 'drs4_pedestal_path': test_drs4_pedestal_path,
                 'drs4_time_calibration_path': test_time_calib_path,

--- a/ctapipe_io_lst/tests/test_event_time.py
+++ b/ctapipe_io_lst/tests/test_event_time.py
@@ -1,11 +1,14 @@
+import logging
 import os
 from pathlib import Path
 import numpy as np
-from ctapipe_io_lst.containers import LSTArrayEventContainer
+
 from astropy.table import Table
 from astropy.time import Time
 import astropy.units as u
+
 from ctapipe_io_lst.constants import N_MODULES
+from ctapipe_io_lst.containers import LSTArrayEventContainer
 
 test_data = Path(os.getenv('LSTCHAIN_TEST_DATA', 'test_data'))
 test_night_summary = test_data / 'real/monitoring/NightSummary/NightSummary_20200218.txt'
@@ -73,11 +76,8 @@ def test_ucts_jumps():
     s_to_ns = int(1e9)
     time_calculator = EventTimeCalculator(
         subarray=subarray,
-        ucts_t0_dragon=true_time_s * s_to_ns,
-        dragon_counter0=0,
-        ucts_t0_tib=true_time_s * s_to_ns,
-        tib_counter0=0,
-        use_first_event=False,
+        dragon_reference_time=true_time_s * s_to_ns,
+        dragon_reference_counter=0,
         timestamp='ucts'  # use ucts to make sure we identify jumps and fallback to tib
     )
 
@@ -139,3 +139,61 @@ def test_ucts_jumps():
         ucts_trigger_types.append(lst.evt.ucts_trigger_type)
 
     assert np.all(np.array(ucts_trigger_types) == table['event_id'])
+
+
+
+def test_no_reference(caplog):
+    '''
+    Test that we switch to `event.lst.svc.date` as reference when
+    no reference is available.
+    '''
+    from ctapipe_io_lst.event_time import EventTimeCalculator
+    from ctapipe_io_lst import LSTEventSource
+
+    caplog.set_level(logging.WARNING)
+
+    tel_id = 1
+    event = LSTArrayEventContainer()
+    lst = event.lst.tel[tel_id]
+    lst.evt.extdevices_presence = 0b1111_1101
+    lst.svc.module_ids = np.arange(N_MODULES)
+
+    subarray = LSTEventSource.create_subarray(geometry_version=4, tel_id=1)
+
+    first_event_time = Time.now()
+    # run start is a couple of seconds earlier than first event
+    lst.svc.date = (first_event_time - 5 * u.s).unix
+
+    s_to_ns = int(1e9)
+
+    n_events = 5
+    true_event_id = np.arange(n_events)
+    true_time_s = int(first_event_time.unix)
+    # one event every 100 micro seconds
+    true_time_ns = int(1e5) * true_event_id
+
+    time_calculator = EventTimeCalculator(
+        subarray=subarray,
+    )
+
+    table = Table({
+        'event_id': true_event_id,
+        'ucts_timestamp': np.zeros(n_events, dtype=int),
+        'pps_counter': [np.full(N_MODULES, 100) for _ in range(n_events)],
+        'tenMHz_counter': [np.full(N_MODULES, int(t / 100)) for t in true_time_ns],
+    })
+
+    for i in range(n_events):
+        for col in table.colnames:
+            setattr(lst.evt, col, table[col][i])
+
+        time = time_calculator(tel_id, event)
+        expected_time = first_event_time + (i * 100 * u.us - 5 * u.s)
+        # precision of float64 timestamp around 300 ns
+        assert np.abs((time - expected_time).to_value(u.us)) < 0.5
+
+    warning_found = False
+    for record in caplog.records:
+        if 'Cannot calculate a precise timestamp' in record.message:
+            warning_found = True
+    assert warning_found

--- a/ctapipe_io_lst/tests/test_event_time.py
+++ b/ctapipe_io_lst/tests/test_event_time.py
@@ -25,9 +25,18 @@ int_cols = [
 ]
 
 
+
 def test_time_unix_tai():
     t = Time('2020-01-01T00:00:00', scale='utc')
     assert (t.unix_tai - t.unix) == 37
+
+
+def test_time_from_unix_tai_ns():
+    from ctapipe_io_lst.event_time import time_from_unix_tai_ns
+
+    time = Time.now()
+    result = time_from_unix_tai_ns(int(time.unix_tai * 1e9))
+    assert np.isclose((result - time).to_value(u.us), 0, atol=0.5)
 
 
 def test_read_night_summary():

--- a/ctapipe_io_lst/tests/test_lsteventsource.py
+++ b/ctapipe_io_lst/tests/test_lsteventsource.py
@@ -82,7 +82,7 @@ def test_subarray():
 
 def test_missing_modules():
     from ctapipe.io import EventSource
-    source = EventSource(test_missing_module_path, fill_timestamp=False)
+    source = EventSource(test_missing_module_path)
 
     fill = np.iinfo(np.uint16).max
     for event in source:

--- a/ctapipe_io_lst/tests/test_lsteventsource.py
+++ b/ctapipe_io_lst/tests/test_lsteventsource.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 import tempfile
 from ctapipe_io_lst.constants import N_GAINS, N_PIXELS_MODULE, N_SAMPLES
+from traitlets.config import Config
 
 test_data = Path(os.getenv('LSTCHAIN_TEST_DATA', 'test_data')).absolute()
 test_r0_dir = test_data / 'real/R0/20200218'
@@ -14,13 +15,17 @@ test_missing_module_path = test_data / 'real/R0/20210215/LST-1.1.Run03669.0000_f
 # ADC_SAMPLES_SHAPE = (2, 14, 40)
 
 
+config = Config()
+config.LSTEventSouce.EventTimeCalculator.extract_reference = True
+
+
 def test_loop_over_events():
     from ctapipe_io_lst import LSTEventSource
 
     n_events = 10
     source = LSTEventSource(
         input_url=test_r0_path,
-        max_events=n_events
+        max_events=n_events,
     )
 
     for i, event in enumerate(source):


### PR DESCRIPTION
* Since times calculated based on the dragon counters are the most precise
  and it is always possible to calculate them, there is no reason to use
  TIB counters for time, so the option to calculate time based on TIB is
  removed.

* If reference counters / timestamps for dragon time are not given,
  the run start timestamp svc.date is used, which results in timestamps
  being off by an unknown amount of seconds. These timestamps can
  still be usefull for tracking relative times or interpolating
  pointing, but not for precise event time stamps.