### PR TITLE
Allow dragon reference values to be read from the RunSummary

### DIFF
--- a/ctapipe_io_lst/__init__.py
+++ b/ctapipe_io_lst/__init__.py
@@ -21,8 +21,8 @@ from enum import IntFlag, auto
 
 from ctapipe.io import EventSource
 from ctapipe.io.datalevels import DataLevel
-from ctapipe.core.traits import Int, Bool, Float, Enum
-from ctapipe.containers import PixelStatusContainer, EventType, NAN_TIME
+from ctapipe.core.traits import Int, Bool, Float, Enum, Path
+from ctapipe.containers import PixelStatusContainer, EventType
 
 from .containers import LSTArrayEventContainer, LSTServiceContainer
 from .version import __version__
@@ -238,7 +238,12 @@ class LSTEventSource(EventSource):
         self.r0_r1_calibrator = LSTR0Corrections(
             subarray=self._subarray, parent=self
         )
-        self.time_calculator = EventTimeCalculator(subarray=self.subarray, parent=self)
+        self.time_calculator = EventTimeCalculator(
+            subarray=self.subarray,
+            run_id=self.camera_config.configuration_id,
+            expected_modules_id=self.camera_config.lstcam.expected_modules_id,
+            parent=self,
+        )
         self.pointing_source = PointingSource(subarray=self.subarray, parent=self)
 
     @property

--- a/ctapipe_io_lst/anyarray_dtypes.py
+++ b/ctapipe_io_lst/anyarray_dtypes.py
@@ -40,7 +40,7 @@ CDTS_BEFORE_37201_DTYPE = np.dtype([
     ('camera_timestamp', np.uint64),
     ('trigger_type', np.uint8),
     ('white_rabbit_status', np.uint8),
-    ('unknown', np.uint8),
+    ('unknown', np.uint8),  # called arbitraryInformation in C-Struct
 ]).newbyteorder('<')
 
 SWAT_DTYPE = np.dtype([

--- a/ctapipe_io_lst/tests/test_stage1.py
+++ b/ctapipe_io_lst/tests/test_stage1.py
@@ -15,17 +15,13 @@ test_calib_path = test_data / 'real/calibration/20200218/v05/calibration.Run2006
 test_drs4_pedestal_path = test_data / 'real/calibration/20200218/v05/drs4_pedestal.Run2005.0000.fits'
 test_time_calib_path = test_data / 'real/calibration/20200218/v05/time_calibration.Run2006.0000.hdf5'
 test_drive_report = test_data / 'real/monitoring/DrivePositioning/drive_log_20200218.txt'
-test_night_summary = test_data / 'real/monitoring/NightSummary/NightSummary_20200218.txt'
+test_run_summary = test_data / 'real/monitoring/RunSummary/RunSummary_20200218.ecsv'
 
 
 def test_stage1(tmpdir):
     """Test the ctapipe stage1 tool can read in LST real data using the event source"""
     from ctapipe.tools.stage1 import Stage1Tool
     from ctapipe.core.tool import run_tool
-    from ctapipe_io_lst.event_time import read_night_summary
-
-    summary = read_night_summary(test_night_summary)
-    run_info = summary.loc[2008]
 
     tmpdir = Path(tmpdir)
     config_path = tmpdir / 'config.json'
@@ -41,8 +37,7 @@ def test_stage1(tmpdir):
                 'drive_report_path': str(test_drive_report)
             },
             'EventTimeCalculator': {
-                'dragon_reference_time': int(run_info['ucts_t0_dragon']),
-                'dragon_reference_counter': int(run_info['dragon_counter0']),
+                'run_summary_path': str(test_run_summary),
             },
         },
         "CameraCalibrator": {

--- a/example_stage1_config.json
+++ b/example_stage1_config.json
@@ -14,8 +14,7 @@
       "drive_report_path": "test_data/real/monitoring/DrivePositioning/drive_log_20200218.txt"
     },
     "EventTimeCalculator": {
-      "dragon_reference_time": 1582059789516351903,
-      "dragon_reference_counter": 2516351600
+      "run_summary_path": "test_data/real/monitoring/RunSummary/RunSummary_20200218.ecsv"
     }
   },
   "CameraCalibrator": {


### PR DESCRIPTION
This reads the run summary files as produced by https://github.com/cta-observatory/cta-lstchain/pull/614 .

This is ready to be reviewed, but I will put it in draft mode until that PR is merged.