### PR TITLE
Expose service container at source

### DIFF
--- a/ctapipe_io_lst/__init__.py
+++ b/ctapipe_io_lst/__init__.py
@@ -240,6 +240,7 @@ class LSTEventSource(EventSource):
         )
         self.time_calculator = EventTimeCalculator(subarray=self.subarray, parent=self)
         self.pointing_source = PointingSource(subarray=self.subarray, parent=self)
+        self.lst_service = self.fill_lst_service_container(self.tel_id, self.camera_config)
 
     @property
     def subarray(self):
@@ -312,8 +313,8 @@ class LSTEventSource(EventSource):
         array_event.meta['max_events'] = self.max_events
         array_event.meta['origin'] = 'LSTCAM'
 
-        # fill LST data from the CameraConfig table
-        array_event.lst.tel[self.tel_id].svc = self.fill_lst_service_container()
+        # also add service container to the event section
+        array_event.lst.tel[self.tel_id].svc = self.lst_service
 
         # initialize general monitoring container
         self.initialize_mon_container(array_event)
@@ -387,29 +388,28 @@ class LSTEventSource(EventSource):
         is_lst_file = 'lstcam_counters' in ttypes
         return is_protobuf_zfits_file & is_lst_file
 
-    def fill_lst_service_container(self):
+    @staticmethod
+    def fill_lst_service_container(tel_id, camera_config):
         """
         Fill LSTServiceContainer with specific LST service data data
         (from the CameraConfig table of zfit file)
 
         """
-        tel_id = self.tel_id
-
         return LSTServiceContainer(
-            telescope_id = tel_id,
-            cs_serial=self.camera_config.cs_serial,
-            configuration_id=self.camera_config.configuration_id,
-            date=self.camera_config.date,
-            num_pixels=self.camera_config.num_pixels,
-            num_samples=self.camera_config.num_samples,
-            pixel_ids=self.camera_config.expected_pixels_id,
-            data_model_version=self.camera_config.data_model_version,
-            num_modules=self.camera_config.lstcam.num_modules,
-            module_ids=self.camera_config.lstcam.expected_modules_id,
-            idaq_version=self.camera_config.lstcam.idaq_version,
-            cdhs_version=self.camera_config.lstcam.cdhs_version,
-            algorithms=self.camera_config.lstcam.algorithms,
-            pre_proc_algorithms=self.camera_config.lstcam.pre_proc_algorithms,
+            telescope_id=tel_id,
+            cs_serial=camera_config.cs_serial,
+            configuration_id=camera_config.configuration_id,
+            date=camera_config.date,
+            num_pixels=camera_config.num_pixels,
+            num_samples=camera_config.num_samples,
+            pixel_ids=camera_config.expected_pixels_id,
+            data_model_version=camera_config.data_model_version,
+            num_modules=camera_config.lstcam.num_modules,
+            module_ids=camera_config.lstcam.expected_modules_id,
+            idaq_version=camera_config.lstcam.idaq_version,
+            cdhs_version=camera_config.lstcam.cdhs_version,
+            algorithms=camera_config.lstcam.algorithms,
+            pre_proc_algorithms=camera_config.lstcam.pre_proc_algorithms,
         )
 
     def fill_lst_event_container(self, array_event, zfits_event):

--- a/ctapipe_io_lst/tests/test_lsteventsource.py
+++ b/ctapipe_io_lst/tests/test_lsteventsource.py
@@ -61,7 +61,7 @@ def test_is_compatible():
     assert LSTEventSource.is_compatible(test_r0_path)
 
 
-def test_factory_for_lst_file():
+def test_event_source_for_lst_file():
     from ctapipe.io import EventSource
 
     reader = EventSource(test_r0_path)
@@ -74,20 +74,26 @@ def test_factory_for_lst_file():
 
 
 def test_subarray():
-    from ctapipe.io import EventSource
+    from ctapipe_io_lst import LSTEventSource
 
-    source = EventSource(test_r0_path)
+    source = LSTEventSource(test_r0_path)
     subarray = source.subarray
     subarray.info()
     subarray.to_table()
+
+    assert source.lst_service.telescope_id == 1
+    assert source.lst_service.num_modules == 265
 
     with tempfile.NamedTemporaryFile(suffix='.h5') as f:
         subarray.to_hdf(f.name)
 
 
 def test_missing_modules():
-    from ctapipe.io import EventSource
-    source = EventSource(test_missing_module_path)
+    from ctapipe_io_lst import LSTEventSource
+    source = LSTEventSource(test_missing_module_path)
+
+    assert source.lst_service.telescope_id == 1
+    assert source.lst_service.num_modules == 264
 
     fill = np.iinfo(np.uint16).max
     for event in source:


### PR DESCRIPTION
Since the service container only depends on the `CameraConfiguration`, we can already fill it in `__init__` and expose it as a member of the source.

This will make it easier to deal with, for example like here in the PR for the pedestal fits writer:
https://github.com/cta-observatory/cta-lstchain/pull/601/