### PR TITLE
change data type of R0 to int16 instead of uint16

### DIFF
--- a/ctapipe_io_lst/__init__.py
+++ b/ctapipe_io_lst/__init__.py
@@ -623,7 +623,7 @@ class LSTEventSource(EventSource):
 
         # re-order the waveform following the expected_pixels_id values
         #  could also just do waveform = reshaped_waveform[np.argsort(expected_ids)]
-        dtype = reshaped_waveform.dtype
+        dtype = np.int16
         fill = np.iinfo(dtype).max
         reordered_waveform = np.full((self.n_gains, N_PIXELS, N_SAMPLES), fill, dtype=dtype)
         reordered_waveform[:, self.camera_config.expected_pixels_id, :] = reshaped_waveform


### PR DESCRIPTION
This PR is from the issue #91.
In this PR, I just changed the data type of R0 to ‘int16’ instead of ‘uint16’.
This has two merits:
1) When computing pedestal values without EVB baseline correction, R0 data is possibly negative after offline time-lapse correction. The current code would convert this negative one into too high values in uint16.

<img width="655" alt="r3889" src="https://user-images.githubusercontent.com/31307823/112569877-5290f600-8e28-11eb-909c-493c8f94fe06.PNG">


2) In EVB, the data type of R0 is defined as below:
> value = uint16((int16)sample + ((int16)offset - (int16)baseline))

So if the value is negative after EVB correction due to too high pedestal counts by accident or too low signal (<400ADC, e.g. undershoot of the pulse), too high counts are saved in the disk.
The new codes convert those high counts in uint16 to a corresponding negative value in int16.
For now, those too high counts are still kept in R1 stage since the data type of R1 is float32. 
<img width="660" alt="r4224" src="https://user-images.githubusercontent.com/31307823/112570054-ab608e80-8e28-11eb-8c57-e62aa5f2df44.PNG">
