### PR TITLE
Fill 0 instead of nan for missing pixels

### DIFF
--- a/ctapipe_io_lst/calibration.py
+++ b/ctapipe_io_lst/calibration.py
@@ -211,7 +211,7 @@ class LSTR0Corrections(TelescopeComponent):
             waveform -= self.offset.tel[tel_id]
 
             mon = event.mon.tel[tel_id]
-            waveform[mon.pixel_status.hardware_failing_pixels] = np.nan
+            waveform[mon.pixel_status.hardware_failing_pixels] = 0.0
 
     def update_first_capacitors(self, event: ArrayEventContainer):
         for tel_id in event.r0.tel:
@@ -243,7 +243,7 @@ class LSTR0Corrections(TelescopeComponent):
                 waveform *= calibration.dc_to_pe[:, :, np.newaxis]
 
             mon = event.mon.tel[tel_id]
-            waveform[mon.pixel_status.hardware_failing_pixels] = np.nan
+            waveform[mon.pixel_status.hardware_failing_pixels] = 0.0
 
             waveform = waveform.astype(np.float32)
             n_gains, n_pixels, n_samples = waveform.shape


### PR DESCRIPTION
Filling nans breaks the `GlobalPeakWindowSum` extractor used for muon events (And probably also all neighbors of nan pixels with the `NeighborPeakWindowSum`)