### PR TITLE
Spike positions

### DIFF
--- a/ctapipe_io_lst/calibration.py
+++ b/ctapipe_io_lst/calibration.py
@@ -556,8 +556,10 @@ def interpolate_spike_A(waveform, position):
 
 
 @njit(cache=True)
-def interpolate_spikes_pixel(waveform, current_fc, last_fc):
+def get_spike_A_positions(current_fc, last_fc):
     LAST_IN_FIRST_HALF = N_CAPACITORS_CHANNEL // 2 - 1
+
+    positions = []
 
     for k in range(4):
         # looking for spike A first case
@@ -570,7 +572,7 @@ def interpolate_spikes_pixel(waveform, current_fc, last_fc):
             # DRS4 ring
             last_capacitor = (last_fc + N_SAMPLES - 1) % N_CAPACITORS_CHANNEL
             if last_capacitor % 2 == 0 and last_capacitor <= LAST_IN_FIRST_HALF:
-                interpolate_spike_A(waveform, spike_A_position)
+                positions.append(spike_A_position)
 
         # looking for spike A second case
         abspos = N_SAMPLES - 1 + last_fc + k * N_CAPACITORS_CHANNEL
@@ -579,7 +581,16 @@ def interpolate_spikes_pixel(waveform, current_fc, last_fc):
             # The correction is only needed for even last capacitor (lc) in the first half of the DRS4 ring
             last_lc = last_fc + N_SAMPLES - 1
             if last_lc % 2 == 0 and last_lc % N_CAPACITORS_CHANNEL <= (N_CAPACITORS_CHANNEL // 2 - 1):
-                interpolate_spike_A(waveform, spike_A_position)
+                positions.append(spike_A_position)
+
+    return positions
+
+
+@njit(cache=True)
+def interpolate_spikes_pixel(waveform, current_fc, last_fc):
+    positions = get_spike_A_positions(current_fc, last_fc)
+    for spike_A_position in positions:
+        interpolate_spike_A(waveform, spike_A_position)
 
 
 @njit(cache=True)

--- a/ctapipe_io_lst/calibration.py
+++ b/ctapipe_io_lst/calibration.py
@@ -649,6 +649,8 @@ def get_spike_A_positions_old_firmware(current_fc, last_fc):
             if last_lc % 2 == 0 and last_lc % N_CAPACITORS_CHANNEL <= (N_CAPACITORS_CHANNEL // 2 - 1):
                 positions.append(spike_A_position)
 
+    return positions
+
 
 @njit(cache=True)
 def interpolate_spike_positions(waveform, positions):


### PR DESCRIPTION
This adds functions to obtain the positions of the spikes needed for calculating the spike heights to enable spike subtraction instead of interpolation and a function to update the last_readout_times needed to create the time calibration file in this lstchain PR here: https://github.com/cta-observatory/cta-lstchain/pull/725