### PR TITLE
Change default calib scales to unity

### DIFF
--- a/ctapipe_io_lst/calibration.py
+++ b/ctapipe_io_lst/calibration.py
@@ -128,12 +128,12 @@ class LSTR0Corrections(TelescopeComponent):
     ).tag(config=True)
 
     calib_scale_high_gain = FloatTelescopeParameter(
-        default_value=1.18,
+        default_value=1.0,
         help='High gain waveform is multiplied by this number'
     ).tag(config=True)
 
     calib_scale_low_gain = FloatTelescopeParameter(
-        default_value=1.09,
+        default_value=1.0,
         help='Low gain waveform is multiplied by this number'
     ).tag(config=True)
 


### PR DESCRIPTION
As discussed via slack, there is no "correct" default for these calib
scales since they depend on how the calibration was performed.
They have to be set appropriately in the config. A "sane" default is
thus to apply no calib scaling (e.g. both factors = 1.0)