### PR TITLE
Do not subtract an offset by default

### DIFF
--- a/ctapipe_io_lst/calibration.py
+++ b/ctapipe_io_lst/calibration.py
@@ -86,10 +86,12 @@ class LSTR0Corrections(TelescopeComponent):
     This calibrator exists in lstchain for testing and prototyping purposes.
     """
     offset = IntTelescopeParameter(
-        default_value=400,
+        default_value=0,
         help=(
-            'Define the offset of the baseline'
-            ', set to 0 to disable offset subtraction'
+            'Define the offset the offset of the baseline to be subtracted'
+            ' from the waveform *additionally* to the drs4 pedestal offset.'
+            ' Only set this to a value != 0 when not using the drs4 offset '
+            ' calibration.'
         )
     ).tag(config=True)
 
@@ -239,7 +241,9 @@ class LSTR0Corrections(TelescopeComponent):
             end = self.r1_sample_end.tel[tel_id]
             r1.waveform = r1.waveform[..., start:end]
 
-            r1.waveform -= self.offset.tel[tel_id]
+            if self.offset.tel[tel_id] != 0:
+                r1.waveform -= self.offset.tel[tel_id]
+
             mon = event.mon.tel[tel_id]
             if r1.selected_gain_channel is None:
                 r1.waveform[mon.pixel_status.hardware_failing_pixels] = 0.0
@@ -400,7 +404,7 @@ class LSTR0Corrections(TelescopeComponent):
 
     @staticmethod
     @lru_cache(maxsize=4)
-    def _get_drs4_pedestal_data(path, offset=0):
+    def _get_drs4_pedestal_data(path):
         """
         Function to load pedestal file.
 
@@ -425,9 +429,6 @@ class LSTR0Corrections(TelescopeComponent):
 
         pedestal_data[:, :, N_CAPACITORS_PIXEL:] = pedestal_data[:, :, :N_SAMPLES]
 
-        if offset != 0:
-            pedestal_data -= offset
-
         return pedestal_data
 
     def subtract_pedestal(self, event, tel_id):
@@ -440,9 +441,9 @@ class LSTR0Corrections(TelescopeComponent):
         tel_id : id of the telescope
         """
         pedestal = self._get_drs4_pedestal_data(
-            self.drs4_pedestal_path.tel[tel_id],
-            offset=self.offset.tel[tel_id],
+            self.drs4_pedestal_path.tel[tel_id]
         )
+
         if event.r1.tel[tel_id].selected_gain_channel is None:
             subtract_pedestal(
                 event.r1.tel[tel_id].waveform,

--- a/ctapipe_io_lst/calibration.py
+++ b/ctapipe_io_lst/calibration.py
@@ -88,8 +88,8 @@ class LSTR0Corrections(TelescopeComponent):
     offset = IntTelescopeParameter(
         default_value=0,
         help=(
-            'Define the offset the offset of the baseline to be subtracted'
-            ' from the waveform *additionally* to the drs4 pedestal offset.'
+            'Define offset to be subtracted from the waveform *additionally*'
+            ' to the drs4 pedestal offset.'
             ' Only set this to a value != 0 when not using the drs4 offset '
             ' calibration.'
         )

--- a/ctapipe_io_lst/calibration.py
+++ b/ctapipe_io_lst/calibration.py
@@ -89,9 +89,9 @@ class LSTR0Corrections(TelescopeComponent):
         default_value=0,
         help=(
             'Define offset to be subtracted from the waveform *additionally*'
-            ' to the drs4 pedestal offset.'
-            ' Only set this to a value != 0 when not using the drs4 offset '
-            ' calibration.'
+            ' to the drs4 pedestal offset. This only needs to be given when'
+            ' the drs4 pedestal calibration is not applied or the offset of the'
+            ' drs4 run is different from the data run'
         )
     ).tag(config=True)
 

--- a/ctapipe_io_lst/tests/test_calib.py
+++ b/ctapipe_io_lst/tests/test_calib.py
@@ -64,12 +64,6 @@ def test_read_drs4_pedestal_file():
     # check circular boundary
     assert np.all(pedestal[..., :N_SAMPLES] == pedestal[..., N_CAPACITORS_PIXEL:])
 
-    # check offset is applied
-    pedestal_offset = LSTR0Corrections._get_drs4_pedestal_data(
-        test_drs4_pedestal_path, offset=100,
-    )
-    assert np.all((pedestal - pedestal_offset) == 100)
-
 
 def test_read_drs_time_calibration_file():
     from ctapipe_io_lst.calibration import LSTR0Corrections, N_GAINS, N_PIXELS

--- a/ctapipe_io_lst/tests/test_lsteventsource.py
+++ b/ctapipe_io_lst/tests/test_lsteventsource.py
@@ -129,6 +129,7 @@ def test_gain_selected():
                 apply_drs4_pedestal_correction=False,
                 apply_spike_correction=False,
                 apply_timelapse_correction=False,
+                offset=400,
             )
         )
     ))


### PR DESCRIPTION
This changes how the global offset subtraction is done in
ctapipe_io_lst.
Instead of subtracting `offset` from both the waveform and the drs4
pedestal, we now rely on the offset being part of the drs4 pedestal.

This means, that when the drs4 pedestal calibration is used, no offset
needs to be given, making it possible to analyze runs with different
offsets without adapting the configuration.