### PR TITLE
Add options for loading trigger and pointing info

### DIFF
--- a/ctapipe_io_lst/tests/test_calib.py
+++ b/ctapipe_io_lst/tests/test_calib.py
@@ -30,7 +30,11 @@ def test_get_first_capacitor():
     )
 
     tel_id = 1
-    source = LSTEventSource(test_r0_calib_path, apply_drs4_corrections=False)
+    source = LSTEventSource(
+        test_r0_calib_path,
+        apply_drs4_corrections=False,
+        pointing_information=False,
+    )
     event = next(iter(source))
 
     first_capacitor_id = event.lst.tel[tel_id].evt.first_capacitor_id
@@ -95,6 +99,7 @@ def test_source_with_drs4_pedestal():
 
     config = Config({
         'LSTEventSource': {
+            'pointing_information': False,
             'LSTR0Corrections': {
                 'drs4_pedestal_path': test_drs4_pedestal_path,
             },
@@ -117,6 +122,7 @@ def test_source_with_calibration():
 
     config = Config({
         'LSTEventSource': {
+            'pointing_information': False,
             'LSTR0Corrections': {
                 'drs4_pedestal_path': test_drs4_pedestal_path,
                 'calibration_path': test_calib_path,
@@ -140,6 +146,7 @@ def test_source_with_all():
 
     config = Config({
         'LSTEventSource': {
+            'pointing_information': False,
             'LSTR0Corrections': {
                 'drs4_pedestal_path': test_drs4_pedestal_path,
                 'drs4_time_calibration_path': test_time_calib_path,
@@ -166,6 +173,7 @@ def test_missing_module():
 
     config = Config({
         'LSTEventSource': {
+            'pointing_information': False,
             'LSTR0Corrections': {
                 'drs4_pedestal_path': test_drs4_pedestal_path,
                 'drs4_time_calibration_path': test_time_calib_path,
@@ -203,6 +211,7 @@ def test_no_gain_selection():
 
     config = Config({
         'LSTEventSource': {
+            'pointing_information': False,
             'LSTR0Corrections': {
                 'drs4_pedestal_path': test_drs4_pedestal_path,
                 'drs4_time_calibration_path': test_time_calib_path,
@@ -265,6 +274,7 @@ def test_no_gain_selection_no_drs4time_calib():
 
     config = Config({
         'LSTEventSource': {
+            'pointing_information': False,
             'LSTR0Corrections': {
                 'drs4_pedestal_path': test_drs4_pedestal_path,
                 'calibration_path': test_calib_path,
@@ -291,6 +301,7 @@ def test_already_gain_selected():
 
     config = Config({
         'LSTEventSource': {
+            'pointing_information': False,
             'LSTR0Corrections': {
                 'drs4_pedestal_path': test_drs4_pedestal_path,
                 'drs4_time_calibration_path': test_time_calib_path,


### PR DESCRIPTION
This makes changes like was done to the drs4 calibration to the pointing information and trigger information.

Both are now by default true and it is required to give a drive report when requesting pointing information. This will lead to clearer errors when pointing info is needed and avoid the "No drive report given, pointing info will not be filled" warning in case no pointing information is required.