### PR TITLE
Update ctapipe to 0.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
-        ctapipe-version: [v0.10.5, v0.11.0]
+        python-version: ["3.7", "3.8"]
+        ctapipe-version: ["v0.12.0", ]
 
     steps:
       - uses: actions/checkout@v2

--- a/ctapipe_io_lst/__init__.py
+++ b/ctapipe_io_lst/__init__.py
@@ -24,6 +24,7 @@ from ctapipe.core.traits import Bool, Float, Enum, Path
 from ctapipe.containers import (
     PixelStatusContainer, EventType, R0CameraContainer, R1CameraContainer,
 )
+from ctapipe.coordinates import CameraFrame
 
 from .multifiles import MultiFiles
 from .containers import LSTArrayEventContainer, LSTServiceContainer
@@ -110,7 +111,9 @@ def load_camera_geometry(version=4):
         'ctapipe_io_lst', f'resources/LSTCam-{version:03d}.camgeom.fits.gz'
     )
     Provenance().add_input_file(f, role="CameraGeometry")
-    return CameraGeometry.from_table(f)
+    cam = CameraGeometry.from_table(f)
+    cam.frame = CameraFrame(focal_length=OPTICS.equivalent_focal_length)
+    return cam
 
 
 def read_pulse_shapes():
@@ -229,7 +232,9 @@ class LSTEventSource(EventSource):
     ).tag(config=True)
 
     pedestal_ids_path = Path(
+        default_value=None,
         exists=True,
+        allow_none=True,
         help=(
             'Path to a file containing the ids of the interleaved pedestal events'
             ' for the current input file'

--- a/ctapipe_io_lst/calibration.py
+++ b/ctapipe_io_lst/calibration.py
@@ -108,7 +108,7 @@ class LSTR0Corrections(TelescopeComponent):
     ).tag(config=True)
 
     drs4_pedestal_path = TelescopeParameter(
-        trait=Path(exists=True, directory_ok=False),
+        trait=Path(exists=True, directory_ok=False, allow_none=True),
         allow_none=True,
         default_value=None,
         help=(
@@ -119,12 +119,12 @@ class LSTR0Corrections(TelescopeComponent):
     ).tag(config=True)
 
     calibration_path = Path(
-        exists=True, directory_ok=False,
+        None, exists=True, directory_ok=False, allow_none=True,
         help='Path to LST calibration file',
     ).tag(config=True)
 
     drs4_time_calibration_path = TelescopeParameter(
-        trait=Path(exists=True, directory_ok=False),
+        trait=Path(exists=True, directory_ok=False, allow_none=True),
         help='Path to the time calibration file',
         default_value=None,
         allow_none=True,

--- a/ctapipe_io_lst/event_time.py
+++ b/ctapipe_io_lst/event_time.py
@@ -177,7 +177,7 @@ class EventTimeCalculator(TelescopeComponent):
     ).tag(config=True)
 
     run_summary_path = TelescopeParameter(
-        Path(exists=True, directory_ok=False),
+        Path(exists=True, directory_ok=False, allow_none=True),
         default_value=None,
         help=(
             'Path to the run summary for the correct night.'

--- a/ctapipe_io_lst/pointing.py
+++ b/ctapipe_io_lst/pointing.py
@@ -17,7 +17,7 @@ NAN_ANGLE = np.nan * u.deg
 class PointingSource(TelescopeComponent):
     """Provides access to pointing information stored in LST drive reports."""
     drive_report_path = TelescopeParameter(
-        trait=Path(exists=True, directory_ok=False),
+        trait=Path(exists=True, directory_ok=False, allow_none=True),
         help='Path to the LST drive report file',
         default_value=None,
     ).tag(config=True)

--- a/ctapipe_io_lst/tests/test_stage1.py
+++ b/ctapipe_io_lst/tests/test_stage1.py
@@ -18,13 +18,12 @@ test_drive_report = test_data / 'real/monitoring/DrivePositioning/drive_log_2020
 test_run_summary = test_data / 'real/monitoring/RunSummary/RunSummary_20200218.ecsv'
 
 
-def test_stage1(tmpdir):
+def test_stage1(tmp_path):
     """Test the ctapipe stage1 tool can read in LST real data using the event source"""
-    from ctapipe.tools.stage1 import Stage1Tool
+    from ctapipe.tools.process import ProcessorTool
     from ctapipe.core.tool import run_tool
 
-    tmpdir = Path(tmpdir)
-    config_path = tmpdir / 'config.json'
+    config_path = tmp_path / 'config.json'
 
     config = {
         'LSTEventSource': {
@@ -58,8 +57,8 @@ def test_stage1(tmpdir):
     with config_path.open('w') as f:
         json.dump(config, f)
 
-    tool = Stage1Tool()
-    output = tmpdir / "test_dl1.h5"
+    tool = ProcessorTool()
+    output = tmp_path / "test_dl1.h5"
 
     ret = run_tool(tool, argv=[
         f'--input={test_r0_path}',
@@ -89,13 +88,12 @@ def test_stage1(tmpdir):
     assert event_type_counts[EventType.SUBARRAY.value] == 198
 
 
-def test_no_ff_tagging(tmpdir):
+def test_no_ff_tagging(tmp_path):
     """Test the ctapipe stage1 tool can read in LST real data using the event source"""
-    from ctapipe.tools.stage1 import Stage1Tool
+    from ctapipe.tools.process import ProcessorTool
     from ctapipe.core.tool import run_tool
 
-    tmpdir = Path(tmpdir)
-    config_path = tmpdir / 'config.json'
+    config_path = tmp_path / 'config.json'
 
     config = {
         'LSTEventSource': {
@@ -130,8 +128,8 @@ def test_no_ff_tagging(tmpdir):
     with config_path.open('w') as f:
         json.dump(config, f)
 
-    tool = Stage1Tool()
-    output = tmpdir / "test_dl1.h5"
+    tool = ProcessorTool()
+    output = tmp_path / "test_dl1.h5"
 
     ret = run_tool(tool, argv=[
         f'--input={test_r0_path}',

--- a/environment.yml
+++ b/environment.yml
@@ -4,11 +4,10 @@ channels:
 dependencies:
   - astropy>=4.2
   - python=3.8 # nail the python version, so conda does not try upgrading / dowgrading
-  - conda-forge::ctapipe=0.11
+  - conda-forge::ctapipe=0.12
   - conda-forge::eventio
   - conda-forge::corsikaio
   - conda-forge::protozfits=2.0
-  - traitlets=5.0 # remove when upgrading to ctapipe > 0.11
   - zeromq
   - ipython
   - numba

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,9 @@ setup(
     use_scm_version={"write_to": os.path.join("ctapipe_io_lst", "_version.py")},
     install_requires=[
         'astropy~=4.2',
-        'ctapipe>=0.10.5,<0.12',
+        'ctapipe~=0.12',
         'protozfits~=2.0',
         'setuptools_scm',
-        'traitlets~=5.0.5', # remove when upgrading to ctapipe > 0.11
     ],
     package_data={
         'ctapipe_io_lst': ['resources/*'],


### PR DESCRIPTION
Small changes to make the source compatible with 0.12.

Let's discuss if we want to switch to 0.12 for the new lstchain version already or later.