### PR TITLE
Fix biased r1 waveform after delta T correction

### DIFF
--- a/ctapipe_io_lst/calibration.py
+++ b/ctapipe_io_lst/calibration.py
@@ -968,8 +968,7 @@ def apply_timelapse_correction_pixel(
 
             # FIXME: Why only for values < 100 ms, negligible otherwise?
             if time_diff_ms < 100:
-                # prevent underflow of the unsigned int value
-                waveform[sample] -= min(ped_time(time_diff_ms), waveform[sample])
+                waveform[sample] -= ped_time(time_diff_ms)
 
 
 @njit(cache=True)

--- a/ctapipe_io_lst/tests/test_calib.py
+++ b/ctapipe_io_lst/tests/test_calib.py
@@ -229,40 +229,6 @@ def test_no_gain_selection():
             assert event.r1.tel[1].waveform.shape == (N_GAINS, N_PIXELS, N_SAMPLES - 4)
 
 
-def test_timelapse_no_underflow():
-    '''Test that the timelapse calibration does not create an underflow'''
-    from ctapipe_io_lst.calibration import apply_timelapse_correction
-    from ctapipe_io_lst.constants import (
-        N_GAINS, N_PIXELS, N_SAMPLES, N_MODULES,
-        N_CAPACITORS_PIXEL, CLOCK_FREQUENCY_KHZ,
-        LAST_RUN_WITH_OLD_FIRMWARE,
-    )
-    from ctapipe_io_lst.calibration import ped_time
-
-    # low value that should underflow if not checked
-    waveform = np.full((N_GAINS, N_PIXELS, N_SAMPLES), 5, dtype=np.uint16)
-
-    # 0.1 ms should result in a correction around 50 ADC samples, well above 5
-    delta_t_ms = 0.1
-    local_clock_counter = np.full(N_MODULES, delta_t_ms * CLOCK_FREQUENCY_KHZ, dtype=np.uint64)
-
-    # make sure we would actually trigger an underflow
-    assert np.all(ped_time(delta_t_ms) > waveform)
-
-    first_capacitors = np.zeros((N_GAINS, N_PIXELS), dtype=np.int16)
-    last_readout_time = np.ones((N_GAINS, N_PIXELS, N_CAPACITORS_PIXEL), dtype=np.uint64)
-    expected_pixels_id = np.arange(N_PIXELS)
-
-    apply_timelapse_correction(
-        waveform,
-        local_clock_counter,
-        first_capacitors,
-        last_readout_time,
-        expected_pixels_id,
-        run_id=LAST_RUN_WITH_OLD_FIRMWARE + 10,
-    )
-    assert np.all(waveform == 0)
-
 def test_no_gain_selection_no_drs4time_calib():
     from ctapipe_io_lst import LSTEventSource
     from ctapipe_io_lst.constants import N_PIXELS, N_GAINS, N_SAMPLES


### PR DESCRIPTION
An unintended side effect of relying on the drs4 offsets to also subtract the base offset of the waveform so that it does not have to be known is that now the waveform is already centered around 0 when applying the delta T correction.

The limit introduced here #95 thus now prevents any negative samples, biasing the pedestal estimation.

I see three options:

* Reintroduce the offset
* Remove the limit on the value that is subtracted from the waveform (done for now in this PR)
* Switch the order in which baseline and timelapse correction are applied, so that the waveform going into the timelapse correction is still around 400, not around 0.

Any opinions?