### PR TITLE
Improve dtype handling in time_from_unix_tai_ns, improve test

### DIFF
--- a/ctapipe_io_lst/event_time.py
+++ b/ctapipe_io_lst/event_time.py
@@ -95,9 +95,12 @@ def time_from_unix_tai_ns(unix_tai_ns):
     By using both arguments to time, the result will be a higher precision
     timestamp.
     '''
-    full_seconds = unix_tai_ns // S_TO_NS
-    fractional_seconds = (unix_tai_ns % S_TO_NS) * 1e-9
-    return Time(full_seconds, fractional_seconds, format='unix_tai')
+    # we need to make sure that the input argument is of type uint64
+    # otherwise the operations below will cast to float64 and loose precision
+    # since unix time in ns is larger than 2^53 for current and future dates
+    unix_tai_ns = np.asanyarray(unix_tai_ns, dtype=np.uint64)
+    seconds, nanoseconds = np.divmod(unix_tai_ns, S_TO_NS)
+    return Time(seconds, nanoseconds / S_TO_NS, format='unix_tai')
 
 
 def module_id_to_index(expected_module_ids, module_id):

--- a/ctapipe_io_lst/event_time.py
+++ b/ctapipe_io_lst/event_time.py
@@ -100,7 +100,8 @@ def time_from_unix_tai_ns(unix_tai_ns):
     # since unix time in ns is larger than 2^53 for current and future dates
     unix_tai_ns = np.asanyarray(unix_tai_ns, dtype=np.uint64)
     seconds, nanoseconds = np.divmod(unix_tai_ns, S_TO_NS)
-    return Time(seconds, nanoseconds / S_TO_NS, format='unix_tai')
+    fractional_seconds = nanoseconds.astype(np.float64) / S_TO_NS
+    return Time(seconds, fractional_seconds, format='unix_tai')
 
 
 def module_id_to_index(expected_module_ids, module_id):


### PR DESCRIPTION
This fixes `time_from_unix_tai_ns` in case the input is not already an `np.uint64`, which was the case in `ctapipe_io_lst` but could easily not be the case if this function is imported somewhere else.

See this issue in `ctapipe_io_lst nectarcam` for more details:
https://github.com/cta-observatory/ctapipe_io_nectarcam/issues/24