### PR TITLE
Switch to using new drive report logs

### DIFF
--- a/ctapipe_io_lst/pointing.py
+++ b/ctapipe_io_lst/pointing.py
@@ -84,6 +84,7 @@ class PointingSource(TelescopeComponent):
             return {"end_unix": int(tokens[0])}
 
         # state machine for Tracking/not Tracking
+        Provenance().add_input_file(str(path), "target log")
         tracking = False
         targets = []
         with path.open("r") as f:

--- a/ctapipe_io_lst/tests/test_lsteventsource.py
+++ b/ctapipe_io_lst/tests/test_lsteventsource.py
@@ -21,7 +21,7 @@ test_r0_path_all_streams = test_r0_dir / 'LST-1.1.Run02008.0000_first50.fits.fz'
 
 test_missing_module_path = test_data / 'real/R0/20210215/LST-1.1.Run03669.0000_first50.fits.fz'
 
-test_drive_report = test_data / 'real/monitoring/DrivePositioning/drive_log_20200218.txt'
+test_drive_report = test_data / 'real/monitoring/DrivePositioning/DrivePosition_log_20200218.txt'
 
 # ADC_SAMPLES_SHAPE = (2, 14, 40)
 
@@ -218,8 +218,8 @@ def test_pointing_info():
     ) as source:
         for e in source:
             # Tue Feb 18 21:03:09 2020 1582059789 Az 197.318 197.287 197.349 0 El 7.03487 7.03357 7.03618 0.0079844 RA 83.6296 Dec 22.0144
-            assert u.isclose(e.pointing.array_ra, 83.6296 * u.deg)
-            assert u.isclose(e.pointing.array_dec, 22.0144 * u.deg)
+            assert np.isnan(e.pointing.array_ra)
+            assert np.isnan(e.pointing.array_dec)
 
             expected_alt = (90 - 7.03487) * u.deg
             assert u.isclose(e.pointing.tel[1].altitude.to(u.deg), expected_alt, rtol=1e-2)

--- a/ctapipe_io_lst/tests/test_lsteventsource.py
+++ b/ctapipe_io_lst/tests/test_lsteventsource.py
@@ -217,9 +217,8 @@ def test_pointing_info():
         config=Config(config),
     ) as source:
         for e in source:
-            # Tue Feb 18 21:03:09 2020 1582059789 Az 197.318 197.287 197.349 0 El 7.03487 7.03357 7.03618 0.0079844 RA 83.6296 Dec 22.0144
-            assert np.isnan(e.pointing.array_ra)
-            assert np.isnan(e.pointing.array_dec)
+            assert u.isclose(e.pointing.array_ra, 83.6296 * u.deg)
+            assert u.isclose(e.pointing.array_dec, 22.0144 * u.deg)
 
             expected_alt = (90 - 7.03487) * u.deg
             assert u.isclose(e.pointing.tel[1].altitude.to(u.deg), expected_alt, rtol=1e-2)

--- a/ctapipe_io_lst/tests/test_pointing.py
+++ b/ctapipe_io_lst/tests/test_pointing.py
@@ -33,18 +33,20 @@ def test_interpolation():
     )
 
     time = Time('2020-02-18T21:40:21')
-    # El is really zenith distance
-    # Tue Feb 18 21:40:20 2020 1582062020 Az 230.834 230.819 230.849 7.75551 El 10.2514 10.2485 10.2543 0.00948548 RA 86.6333 Dec 22.0144
-    # Tue Feb 18 21:40:23 2020 1582062022 Az 230.896 230.881 230.912 9.03034 El 10.2632 10.2603 10.2661 0.00948689 RA 86.6333 Dec 22.0144
-
+    # relevent lines from drive log:
+    # 1582062020 230.834 10.2514
+    # 1582062022 230.896 10.2632
     pointing = pointing_source.get_pointing_position_altaz(tel_id=1, time=time)
     expected_alt = (90 - 0.5 * (10.2514 + 10.2632)) * u.deg
     assert u.isclose(pointing.altitude, expected_alt)
     assert u.isclose(pointing.azimuth, 0.5 * (230.834 + 230.896) * u.deg)
 
+    # relevant lines from target log
+    # 1582061035 TrackStart 86.6333 22.0144 OffCrabLo142 
+    # 1582062466 TrackEnd 
     ra, dec = pointing_source.get_pointing_position_icrs(tel_id=1, time=time)
-    assert np.isnan(ra)
-    assert np.isnan(dec)
+    assert u.isclose(ra, 86.6333 * u.deg)
+    assert u.isclose(dec, 22.0144 * u.deg)
 
 
 def test_bending_corrections():

--- a/ctapipe_io_lst/tests/test_pointing.py
+++ b/ctapipe_io_lst/tests/test_pointing.py
@@ -1,13 +1,14 @@
 import os
 from pathlib import Path
+import numpy as np
 from astropy.time import Time
 import astropy.units as u
 from ctapipe.core import Provenance
 
 test_data = Path(os.getenv('LSTCHAIN_TEST_DATA', 'test_data'))
-test_drive_report = test_data / 'real/monitoring/DrivePositioning/drive_log_20200218.txt'
-test_bending_report = test_data / 'real/monitoring/DrivePositioning/bendingmodelcorrection_log_22_02_20.txt'
-test_drive_report_with_bending = test_data / 'real/monitoring/DrivePositioning/drive_log_22_02_20.txt'
+test_drive_report = test_data / 'real/monitoring/DrivePositioning/DrivePosition_log_20200218.txt'
+test_bending_report = test_data / 'real/monitoring/DrivePositioning/BendingModelCorrection_log_20220220.txt'
+test_drive_report_with_bending = test_data / 'real/monitoring/DrivePositioning/DrivePosition_log_20220220.txt'
 
 
 def test_read_drive_report():
@@ -16,8 +17,8 @@ def test_read_drive_report():
     drive_report = PointingSource._read_drive_report(test_drive_report)
 
     assert 'time' not in drive_report.colnames
-    assert 'azimuth_avg' in drive_report.colnames
-    assert 'zenith_avg' in drive_report.colnames
+    assert 'azimuth' in drive_report.colnames
+    assert 'zenith' in drive_report.colnames
 
 
 def test_interpolation():
@@ -41,8 +42,8 @@ def test_interpolation():
     assert u.isclose(pointing.azimuth, 0.5 * (230.834 + 230.896) * u.deg)
 
     ra, dec = pointing_source.get_pointing_position_icrs(tel_id=1, time=time)
-    assert u.isclose(ra, 86.6333 * u.deg)
-    assert u.isclose(dec, 22.0144 * u.deg)
+    assert np.isnan(ra)
+    assert np.isnan(dec)
 
 
 def test_bending_corrections():

--- a/ctapipe_io_lst/tests/test_stage1.py
+++ b/ctapipe_io_lst/tests/test_stage1.py
@@ -15,7 +15,7 @@ test_r0_path = test_data / 'real/R0/20200218/LST-1.1.Run02008.0000_first50.fits.
 test_calib_path = test_data / 'real/monitoring/PixelCalibration/LevelA/calibration/20200218/v0.8.2.post2.dev48+gb1343281/calibration_filters_52.Run02006.0000.h5'
 test_drs4_pedestal_path = test_data / 'real/monitoring/PixelCalibration/LevelA/drs4_baseline/20200218/v0.8.2.post2.dev48+gb1343281/drs4_pedestal.Run02005.0000.h5'
 test_time_calib_path = test_data / 'real/monitoring/PixelCalibration/LevelA/drs4_time_sampling_from_FF/20191124/v0.8.2.post2.dev48+gb1343281/time_calibration.Run01625.0000.h5'
-test_drive_report = test_data / 'real/monitoring/DrivePositioning/drive_log_20200218.txt'
+test_drive_report = test_data / 'real/monitoring/DrivePositioning/DrivePosition_log_20200218.txt'
 test_run_summary = test_data / 'real/monitoring/RunSummary/RunSummary_20200218.ecsv'
 
 

--- a/example_stage1_config.json
+++ b/example_stage1_config.json
@@ -11,7 +11,7 @@
       "add_calibration_timeshift": true
     },
     "PointingSource": {
-      "drive_report_path": "test_data/real/monitoring/DrivePositioning/drive_log_20200218.txt"
+      "drive_report_path": "test_data/real/monitoring/DrivePositioning/DrivePosition_log_20200218.txt"
     },
     "EventTimeCalculator": {
       "run_summary_path": "test_data/real/monitoring/RunSummary/RunSummary_20200218.ecsv"


### PR DESCRIPTION
This replaces using the old format with the new format.

@morcuended Heads-Up for osa, after this is released and used by lstchain, you will need to pass the `DrivePosition_log_<YYYYMMDD>.txt` files, not the `drive_position_log_YY_MM_DD.txt` files.


The `array_ra`, `array_dec` values are not filled anymore, they are not available from the files and didn't provide any further information since they were only transformed from the alt/az values. 

