### PR TITLE
Make source compatible with ctapipe 0.18, test with 0.17 and 0.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
-        ctapipe-version: ["v0.17.0", ]
+        ctapipe-version: ["0.17.0", "0.18.0"]
 
     defaults:
       run:
@@ -48,8 +48,8 @@ jobs:
           CTAPIPE_VERSION: ${{ matrix.ctapipe-version }}
         run: |
           pip install -e .
-          # we install ctapipe using pip to be able to select any commit, e.g. the current master
-          pip install pytest-cov "git+https://github.com/cta-observatory/ctapipe@$CTAPIPE_VERSION"
+          pip install pytest-cov "ctapipe==$CTAPIPE_VERSION"
+          ctapipe-info --version | grep "$CTAPIPE_VERSION"
           git describe --tags
 
       - name: Test Plugin

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - astropy=5.2
   - python=3.10 # nail the python version, so conda does not try upgrading / dowgrading
-  - ctapipe=0.17
+  - ctapipe=0.18
   - eventio
   - corsikaio
   - protozfits=2.0

--- a/eventsource_subclasses.py
+++ b/eventsource_subclasses.py
@@ -1,5 +1,7 @@
 from ctapipe.io import EventSource
-from ctapipe.core import non_abstract_children
+import logging
 
-for cls in non_abstract_children(EventSource):
+logging.basicConfig(level=logging.INFO)
+
+for cls in EventSource.non_abstract_subclasses().values():
     print(cls.__name__)

--- a/eventsource_subclasses.py
+++ b/eventsource_subclasses.py
@@ -1,7 +1,5 @@
 from ctapipe.io import EventSource
 import logging
 
-logging.basicConfig(level=logging.INFO)
-
 for cls in EventSource.non_abstract_subclasses().values():
     print(cls.__name__)

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ python_requires = >=3.8
 zip_safe = False
 install_requires=
     astropy~=5.2
-    ctapipe~=0.17.0
+    ctapipe>=0.17.0,<=0.19.0a0
     protozfits~=2.0
     numpy>=1.20
 
@@ -52,6 +52,9 @@ all =
     %(tests)s
     %(dev)s
 
+[options.entry_points]
+ctapipe_io =
+    LSTEventSource = ctapipe_io_lst:LSTEventSource
 
 [tool:pytest]
 minversion = 3.0

--- a/src/ctapipe_io_lst/tests/test_calib.py
+++ b/src/ctapipe_io_lst/tests/test_calib.py
@@ -11,7 +11,7 @@ resource_dir = Path(pkg_resources.resource_filename(
     'ctapipe_io_lst', 'tests/resources'
 ))
 
-test_data = Path(os.getenv('LSTCHAIN_TEST_DATA', 'test_data'))
+test_data = Path(os.getenv('LSTCHAIN_TEST_DATA', 'test_data')).absolute()
 test_r0_path = test_data / 'real/R0/20200218/LST-1.1.Run02008.0000_first50.fits.fz'
 test_r0_calib_path = test_data / 'real/R0/20200218/LST-1.1.Run02006.0004.fits.fz'
 test_missing_module_path = test_data / 'real/R0/20210215/LST-1.1.Run03669.0000_first50.fits.fz'

--- a/src/ctapipe_io_lst/tests/test_event_time.py
+++ b/src/ctapipe_io_lst/tests/test_event_time.py
@@ -11,7 +11,7 @@ import astropy.units as u
 from ctapipe_io_lst.constants import N_MODULES
 from ctapipe_io_lst.containers import LSTArrayEventContainer
 
-test_data = Path(os.getenv('LSTCHAIN_TEST_DATA', 'test_data'))
+test_data = Path(os.getenv('LSTCHAIN_TEST_DATA', 'test_data')).absolute()
 test_run_summary = test_data / 'real/monitoring/RunSummary/RunSummary_20200218.ecsv'
 
 

--- a/src/ctapipe_io_lst/tests/test_pointing.py
+++ b/src/ctapipe_io_lst/tests/test_pointing.py
@@ -5,7 +5,7 @@ from astropy.time import Time
 import astropy.units as u
 from ctapipe.core import Provenance
 
-test_data = Path(os.getenv('LSTCHAIN_TEST_DATA', 'test_data'))
+test_data = Path(os.getenv('LSTCHAIN_TEST_DATA', 'test_data')).absolute()
 test_drive_report = test_data / 'real/monitoring/DrivePositioning/DrivePosition_log_20200218.txt'
 test_bending_report = test_data / 'real/monitoring/DrivePositioning/BendingModelCorrection_log_20220220.txt'
 test_drive_report_with_bending = test_data / 'real/monitoring/DrivePositioning/DrivePosition_log_20220220.txt'

--- a/src/ctapipe_io_lst/tests/test_stage1.py
+++ b/src/ctapipe_io_lst/tests/test_stage1.py
@@ -10,7 +10,7 @@ from astropy.time import Time
 import astropy.units as u
 
 
-test_data = Path(os.getenv('LSTCHAIN_TEST_DATA', 'test_data'))
+test_data = Path(os.getenv('LSTCHAIN_TEST_DATA', 'test_data')).absolute()
 test_r0_path = test_data / 'real/R0/20200218/LST-1.1.Run02008.0000_first50.fits.fz'
 test_drive_report = test_data / 'real/monitoring/DrivePositioning/DrivePosition_log_20200218.txt'
 test_run_summary = test_data / 'real/monitoring/RunSummary/RunSummary_20200218.ecsv'


### PR DESCRIPTION
Basically no changes needed aside from making sure that the test data is given as absolute paths since ctapipe 0.18 now uses a tmp dir by default when using `run_tool`