### PR TITLE
Check # of gains in FF events. 

### DIFF
--- a/src/ctapipe_io_lst/__init__.py
+++ b/src/ctapipe_io_lst/__init__.py
@@ -713,7 +713,7 @@ class LSTEventSource(EventSource):
         if waveform.ndim == 3:
             image = waveform[HIGH_GAIN].sum(axis=1)
         else:
-            return;
+            return
 
         in_range = (image >= self.min_flatfield_adc) & (image <= self.max_flatfield_adc)
         n_in_range = np.count_nonzero(in_range)

--- a/src/ctapipe_io_lst/__init__.py
+++ b/src/ctapipe_io_lst/__init__.py
@@ -730,12 +730,12 @@ class LSTEventSource(EventSource):
             else:
                 array_event.trigger.event_type = EventType.UNKNOWN
                 self.log.warning(
-                'Found FF-looking event that has just one gain:',
-                f'{array_event.index.event_id}. Setting event type to UNKNOWN'
+                    'Found FF-looking event that has just one gain:'
+                    f'{array_event.index.event_id}. Setting event type to UNKNOWN'
                 )
         elif array_event.trigger.event_type == EventType.FLATFIELD:
             self.log.warning(
-                'Found FF event that does not fulfill FF criteria:',
+                'Found FF event that does not fulfill FF criteria:'
                 f'{array_event.index.event_id}. Setting event type to UNKNOWN' 
             )
             array_event.trigger.event_type = EventType.UNKNOWN

--- a/src/ctapipe_io_lst/__init__.py
+++ b/src/ctapipe_io_lst/__init__.py
@@ -688,7 +688,9 @@ class LSTEventSource(EventSource):
         trigger.event_type = self._event_type_from_trigger_bits(trigger_bits)
         
         if trigger.event_type == EventType.FLATFIELD:
-            waveform = array_event.r1.tel[tel_id].waveform
+            waveform = array_event.r0.tel[tel_id].waveform
+            if waveform is None:
+                waveform = array_event.r1.tel[tel_id].waveform
             if waveform.ndim == 2:
                 self.log.warning(f'Event {array_event.index.event_id} tagged as FLATFIELD, but has only one gain!')
         

--- a/src/ctapipe_io_lst/__init__.py
+++ b/src/ctapipe_io_lst/__init__.py
@@ -686,14 +686,12 @@ class LSTEventSource(EventSource):
             )
 
         trigger.event_type = self._event_type_from_trigger_bits(trigger_bits)
-        
+
         if trigger.event_type == EventType.FLATFIELD:
-            waveform = array_event.r0.tel[tel_id].waveform
-            if waveform is None:
-                waveform = array_event.r1.tel[tel_id].waveform
-            if waveform.ndim == 2:
+            waveform = array_event.r1.tel[tel_id].waveform
+            if waveform is not None and waveform.ndim == 2:
                 self.log.warning(f'Event {array_event.index.event_id} tagged as FLATFIELD, but has only one gain!')
-        
+
         if trigger.event_type == EventType.UNKNOWN:
             self.log.warning(f'Event {array_event.index.event_id} has unknown event type, trigger: {trigger_bits:08b}')
 

--- a/src/ctapipe_io_lst/__init__.py
+++ b/src/ctapipe_io_lst/__init__.py
@@ -730,13 +730,13 @@ class LSTEventSource(EventSource):
             else:
                 array_event.trigger.event_type = EventType.UNKNOWN
                 self.log.warning(
-                'Found FF-looking event that has just one gain: %d',
-                array_event.index.event_id, 'Setting event type to UNKNOWN'
+                'Found FF-looking event that has just one gain:',
+                f'{array_event.index.event_id}. Setting event type to UNKNOWN'
                 )
         elif array_event.trigger.event_type == EventType.FLATFIELD:
             self.log.warning(
-                'Found FF event that does not fulfill FF criteria: %d',
-                array_event.index.event_id, 'Setting event type to UNKNOWN' 
+                'Found FF event that does not fulfill FF criteria:',
+                f'{array_event.index.event_id}. Setting event type to UNKNOWN' 
             )
             array_event.trigger.event_type = EventType.UNKNOWN
 


### PR DESCRIPTION
Check # of gains in FF events, and don't apply heuristic tag on 1-gain events.