### PR TITLE
Use importlib resource instead of pkg_resources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-        ctapipe-version: ["0.19.2"]
+        python-version: ["3.9", "3.10", "3.11"]
+        ctapipe-version: ["0.20.0"]
 
     defaults:
       run:

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ install_requires=
     ctapipe~=0.19.0
     protozfits~=2.2
     numpy>=1.20
+    importlib_resources ; python_version < 3.9
 
 [options.package_data]
 * = resources/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
     Topic :: Scientific/Engineering :: Astronomy
     Topic :: Scientific/Engineering :: Physics
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
 
@@ -27,14 +26,13 @@ classifiers =
 packages = find:
 package_dir =
     = src
-python_requires = >=3.8
+python_requires = >=3.9
 zip_safe = False
 install_requires=
     astropy~=5.2
     ctapipe~=0.19.0
     protozfits~=2.2
     numpy>=1.20
-    importlib_resources ; python_version < "3.9"
 
 [options.package_data]
 * = resources/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires=
     ctapipe~=0.19.0
     protozfits~=2.2
     numpy>=1.20
-    importlib_resources ; python_version < 3.9
+    importlib_resources ; python_version < "3.9"
 
 [options.package_data]
 * = resources/*

--- a/src/ctapipe_io_lst/__init__.py
+++ b/src/ctapipe_io_lst/__init__.py
@@ -6,7 +6,7 @@ from ctapipe.instrument.subarray import EarthLocation
 import logging
 import numpy as np
 from astropy import units as u
-from pkg_resources import resource_filename
+from importlib import resources
 from ctapipe.core import Provenance
 from ctapipe.instrument import (
     ReflectorShape,
@@ -93,9 +93,7 @@ def get_channel_info(pixel_status):
 
 def load_camera_geometry():
     ''' Load camera geometry from bundled resources of this repo '''
-    f = resource_filename(
-        'ctapipe_io_lst', 'resources/LSTCam.camgeom.fits.gz'
-    )
+    f = resources.files('ctapipe_io_lst').joinpath('resources/LSTCam.camgeom.fits.gz')
     Provenance().add_input_file(f, role="CameraGeometry")
     cam = CameraGeometry.from_table(f)
     cam.frame = CameraFrame(focal_length=OPTICS.effective_focal_length)
@@ -118,8 +116,7 @@ def read_pulse_shapes():
     # temporary replace the reference pulse shape
     # ("oversampled_pulse_LST_8dynode_pix6_20200204.dat")
     # with a dummy one in order to disable the charge corrections in the charge extractor
-    infilename = resource_filename(
-        'ctapipe_io_lst',
+    infilename = resources.files('ctapipe_io_lst').joinpath(
         'resources/oversampled_pulse_LST_8dynode_pix6_20200204.dat'
     )
 

--- a/src/ctapipe_io_lst/__init__.py
+++ b/src/ctapipe_io_lst/__init__.py
@@ -3,7 +3,6 @@
 EventSource for LSTCam protobuf-fits.fz-files.
 """
 import logging
-import sys
 
 import numpy as np
 from astropy import units as u

--- a/src/ctapipe_io_lst/__init__.py
+++ b/src/ctapipe_io_lst/__init__.py
@@ -8,10 +8,7 @@ import sys
 import numpy as np
 from astropy import units as u
 
-if sys.version_info[:2] < (3, 9):
-    from importlib_resources import files
-else:
-    from importlib.resources import files
+from importlib.resources import files
 
 from astropy.time import Time
 from ctapipe.containers import (

--- a/src/ctapipe_io_lst/tests/test_calib.py
+++ b/src/ctapipe_io_lst/tests/test_calib.py
@@ -5,11 +5,9 @@ from pathlib import Path
 from traitlets.config import Config
 import numpy as np
 import tables
-import pkg_resources
+from importlib import resources
 
-resource_dir = Path(pkg_resources.resource_filename(
-    'ctapipe_io_lst', 'tests/resources'
-))
+resource_dir = resources.files('ctapipe_io_lst') / 'tests/resources'
 
 test_data = Path(os.getenv('LSTCHAIN_TEST_DATA', 'test_data')).absolute()
 test_r0_path = test_data / 'real/R0/20200218/LST-1.1.Run02008.0000_first50.fits.fz'

--- a/src/ctapipe_io_lst/tests/test_calib.py
+++ b/src/ctapipe_io_lst/tests/test_calib.py
@@ -1,9 +1,4 @@
-import sys
-
-if sys.version_info[:2] < (3, 9):
-    from importlib_resources import files
-else:
-    from importlib.resources import files
+from importlib.resources import files
 
 import os
 import pickle

--- a/src/ctapipe_io_lst/tests/test_calib.py
+++ b/src/ctapipe_io_lst/tests/test_calib.py
@@ -1,13 +1,21 @@
-import pickle
-from ctapipe_io_lst.constants import HIGH_GAIN
+import sys
+
+if sys.version_info[:2] < (3, 9):
+    from importlib_resources import files
+else:
+    from importlib.resources import files
+
 import os
+import pickle
 from pathlib import Path
-from traitlets.config import Config
+
 import numpy as np
 import tables
-from importlib import resources
+from traitlets.config import Config
 
-resource_dir = resources.files('ctapipe_io_lst') / 'tests/resources'
+from ctapipe_io_lst.constants import HIGH_GAIN
+
+resource_dir = files('ctapipe_io_lst') / 'tests/resources'
 
 test_data = Path(os.getenv('LSTCHAIN_TEST_DATA', 'test_data')).absolute()
 test_r0_path = test_data / 'real/R0/20200218/LST-1.1.Run02008.0000_first50.fits.fz'
@@ -25,8 +33,10 @@ test_time_calib_path = calib_path / f'drs4_time_sampling_from_FF/20191124/{calib
 def test_get_first_capacitor():
     from ctapipe_io_lst import LSTEventSource
     from ctapipe_io_lst.calibration import (
-        get_first_capacitors_for_pixels,
-        N_GAINS, N_PIXELS_MODULE, N_MODULES,
+        N_GAINS,
+        N_MODULES,
+        N_PIXELS_MODULE,
+        get_first_capacitors_for_pixels
     )
 
     tel_id = 1
@@ -60,7 +70,11 @@ def test_read_calib_file():
 
 
 def test_read_drs4_pedestal_file():
-    from ctapipe_io_lst.calibration import LSTR0Corrections, N_CAPACITORS_PIXEL, N_SAMPLES
+    from ctapipe_io_lst.calibration import (
+        N_CAPACITORS_PIXEL,
+        N_SAMPLES,
+        LSTR0Corrections
+    )
 
     pedestal = LSTR0Corrections._get_drs4_pedestal_data(test_drs4_pedestal_path, tel_id=1)
 
@@ -70,7 +84,7 @@ def test_read_drs4_pedestal_file():
 
 
 def test_read_drs_time_calibration_file():
-    from ctapipe_io_lst.calibration import LSTR0Corrections, N_GAINS, N_PIXELS
+    from ctapipe_io_lst.calibration import N_GAINS, N_PIXELS, LSTR0Corrections
 
     fan, fbn = LSTR0Corrections.load_drs4_time_calibration_file(test_time_calib_path)
 
@@ -201,7 +215,7 @@ def test_missing_module():
 
 def test_no_gain_selection():
     from ctapipe_io_lst import LSTEventSource
-    from ctapipe_io_lst.constants import N_PIXELS, N_GAINS, N_SAMPLES
+    from ctapipe_io_lst.constants import N_GAINS, N_PIXELS, N_SAMPLES
 
     config = Config({
         'LSTEventSource': {
@@ -230,7 +244,7 @@ def test_no_gain_selection():
 
 def test_no_gain_selection_no_drs4time_calib():
     from ctapipe_io_lst import LSTEventSource
-    from ctapipe_io_lst.constants import N_PIXELS, N_GAINS, N_SAMPLES
+    from ctapipe_io_lst.constants import N_GAINS, N_PIXELS, N_SAMPLES
 
     config = Config({
         'LSTEventSource': {


### PR DESCRIPTION
`importlib.resources.files` requires python >= 3.9 (required for next ctapipe v0.20.0)

closes #197 