### PR TITLE
Perform broken pixels check only in case of non-dvred pixels

### DIFF
--- a/src/ctapipe_io_lst/__init__.py
+++ b/src/ctapipe_io_lst/__init__.py
@@ -1033,7 +1033,7 @@ class LSTEventSource(EventSource):
             # the code here works for both cases but not for the hypothetical
             # case of broken pixels marked as broken (so camera config as 1855 pixels)
             # and 1855 pixel_status entries but broken pixels not contained in `waveform`
-            if np.any(broken_pixels) and len(waveform) < n_pixels:
+            if not self.dvr_applied and np.any(broken_pixels) and len(waveform) < n_pixels:
                 raise NotImplementedError(
                     "Case of broken pixels not contained in waveform is not implemented."
                     "If you encounter this error, open an issue in ctapipe_io_lst noting"


### PR DESCRIPTION
Fixes #206 


I checked with the run given, the broken pixels included in the data stream that were for some reason not DVRed are filled with 0 by the source, so all good I would say.
