### PR TITLE
Raise good error message in case border slices removed by EVB

### DIFF
--- a/src/ctapipe_io_lst/__init__.py
+++ b/src/ctapipe_io_lst/__init__.py
@@ -454,12 +454,15 @@ class LSTEventSource(EventSource):
 
         tel_descriptions = {tel_id: lst_tel_descr}
 
-        xyz = ground_frame_from_earth_location(
-            LST_LOCATIONS[tel_id],
-            reference_location,
-        ).cartesian.xyz
-        tel_positions = {tel_id: xyz}
+        try:
+            location = LST_LOCATIONS[tel_id]
+        except KeyError:
+            known = list(LST_LOCATIONS.keys())
+            msg = f"Location missing for tel_id={tel_id}. Known tel_ids: {known}. Is this LST data?"
+            raise KeyError(msg) from None
 
+        ground_frame = ground_frame_from_earth_location(location, reference_location)
+        tel_positions = {tel_id: ground_frame.cartesian.xyz}
         subarray = SubarrayDescription(
             name=f"LST-{tel_id} subarray",
             tel_descriptions=tel_descriptions,

--- a/src/ctapipe_io_lst/calibration.py
+++ b/src/ctapipe_io_lst/calibration.py
@@ -230,6 +230,15 @@ class LSTR0Corrections(TelescopeComponent):
             if r1.waveform is None:
                 r1.waveform = event.r0.tel[tel_id].waveform
 
+            n_samples = r1.waveform.shape[-1]
+            if n_samples != N_SAMPLES:
+                msg = (
+                    f"Data has n_samples={n_samples}, expected {N_SAMPLES}."
+                    " Applying offline drs4 corrections to data with border samples"
+                    " already removed by EVB is not supported."
+                )
+                raise NotImplementedError(msg)
+
             # float32 can represent all values of uint16 exactly,
             # so this does not loose precision.
             r1.waveform = r1.waveform.astype(np.float32, copy=False)


### PR DESCRIPTION
Fixes #227 

We do support reading reduced data in case we do not need to apply DRS4 corrections and we decided not to support the mixed case.

So I just added a clear error message for the unsupported case of trying to apply DRS4 corrections to data with removed samples.