### PR TITLE
support ctapipe 0.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,11 @@ jobs:
         python-version: ["3.10", "3.11"]
         ctapipe-version: ["0.19.3", "0.20.0"]
         include:
-          # ctapipe 0.21 requires >= 3.10
+          # ctapipe >=0.21 requires >= 3.10
           - python-version: "3.12"
             ctapipe-version: "0.21.2"
+          - python-version: "3.12"
+            ctapipe-version: "0.22.0"
 
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
         ctapipe-version: ["0.19.3", "0.20.0"]
         include:
           # ctapipe 0.21 requires >= 3.10
@@ -53,7 +53,8 @@ jobs:
           CTAPIPE_VERSION: ${{ matrix.ctapipe-version }}
         run: |
           pip install -e .
-          pip install pytest-cov "ctapipe==$CTAPIPE_VERSION"
+          # TODO: remove pypi pin when dropping support for ctapipe <0.21
+          pip install pytest-cov "ctapipe==$CTAPIPE_VERSION" "scipy<1.14a0"
           ctapipe-info --version | grep "$CTAPIPE_VERSION"
           git describe --tags
 

--- a/environment.yml
+++ b/environment.yml
@@ -18,4 +18,4 @@ dependencies:
   - zlib
   - pip
   - h5py
-  - scipy <1.14
+  - scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ python_requires = >=3.9
 zip_safe = False
 install_requires=
     astropy >=5.2,<7.0.0a0
-    ctapipe >=0.19.0,<0.22.0a0
+    ctapipe >=0.19.0,<0.23.0a0
     protozfits ~=2.4
     numpy >=1.20
     scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires=
     ctapipe >=0.19.0,<0.22.0a0
     protozfits ~=2.4
     numpy >=1.20
-    scipy <1.14
+    scipy
 
 [options.package_data]
 * = resources/*

--- a/src/ctapipe_io_lst/anyarray_dtypes.py
+++ b/src/ctapipe_io_lst/anyarray_dtypes.py
@@ -70,4 +70,5 @@ def parse_tib_10MHz_counter(counter):
 
     The counter is stored using 3 uint8 values forming a 24-bit unsigned integer
     """
+    counter = counter.astype(np.uint32)
     return counter[0] + (counter[1] << 8) + (counter[2] << 16)


### PR DESCRIPTION
We fixed scipy here to an issue in ctapipe, but this is fixed in the latest version of ctapipe and it doesn't make sense to limit it here in the package metadata.