### PR TITLE
Cache fourier sin/cos computation

### DIFF
--- a/src/ctapipe_io_lst/calibration.py
+++ b/src/ctapipe_io_lst/calibration.py
@@ -3,6 +3,8 @@ from functools import lru_cache
 import numpy as np
 import astropy.units as u
 from numba import njit
+from numba.typed import Dict
+from numba.core import types
 import tables
 
 from ctapipe.core import TelescopeComponent
@@ -1102,6 +1104,20 @@ def ped_time(timediff):
 
 
 
+
+
+_fourier_cache_key_type = types.UniTuple(types.int16, 2)
+_fourier_cache_value_type = types.UniTuple(types.float64[:], 2)
+
+
+@njit(cache=True)
+def _create_fourier_cache():
+    return Dict.empty(
+        key_type=_fourier_cache_key_type,
+        value_type=_fourier_cache_value_type,
+    )
+
+
 @njit(cache=True)
 def calc_drs4_time_correction_gain_selected(
     first_capacitors, selected_gain_channel, fan, fbn
@@ -1109,11 +1125,15 @@ def calc_drs4_time_correction_gain_selected(
     _n_gains, n_pixels, n_harmonics = fan.shape
     time = np.zeros(n_pixels)
 
+    cache = _create_fourier_cache()
     for pixel in range(n_pixels):
         gain = selected_gain_channel[pixel]
         first_capacitor = first_capacitors[gain, pixel]
         time[pixel] = calc_fourier_time_correction(
-            first_capacitor, fan[gain, pixel], fbn[gain, pixel]
+            first_capacitor,
+            fan[gain, pixel],
+            fbn[gain, pixel],
+            cache,
         )
     return time
 
@@ -1124,28 +1144,40 @@ def calc_drs4_time_correction_both_gains(
 ):
     time = np.zeros((N_GAINS, N_PIXELS))
 
+    cache = _create_fourier_cache()
     for gain in range(N_GAINS):
         for pixel in range(N_PIXELS):
             first_capacitor = first_capacitors[gain, pixel]
             time[gain, pixel] = calc_fourier_time_correction(
-                first_capacitor, fan[gain, pixel], fbn[gain, pixel]
+                first_capacitor,
+                fan[gain, pixel],
+                fbn[gain, pixel],
+                cache,
             )
     return time
 
 
+
 @njit(cache=True)
-def calc_fourier_time_correction(first_capacitor, fan, fbn):
+def calc_fourier_time_correction(first_capacitor, fan, fbn, cache):
     n_harmonics = len(fan)
 
     time = 0
     first_capacitor = first_capacitor % N_CAPACITORS_CHANNEL
 
-    for harmonic in range(1, n_harmonics):
-        a = fan[harmonic]
-        b = fbn[harmonic]
-        omega = harmonic * (2 * np.pi / N_CAPACITORS_CHANNEL)
+    cache_key = (types.int16(n_harmonics), types.int16(first_capacitor))
+    cache_val = cache.get(cache_key)
+    if cache_val is not None:
+        sin_terms, cos_terms = cache_val
+    else:
+        n = np.arange(n_harmonics)
+        omega = 2 * np.pi / N_CAPACITORS_CHANNEL
+        sin_terms = np.sin(n * omega * first_capacitor)
+        cos_terms = np.cos(n * omega * first_capacitor)
+        cache[cache_key] = sin_terms, cos_terms
 
-        time += a * np.cos(omega * first_capacitor)
-        time += b * np.sin(omega * first_capacitor)
+    for harmonic in range(1, n_harmonics):
+        time += fan[harmonic] * cos_terms[harmonic]
+        time += fbn[harmonic] * sin_terms[harmonic]
 
     return time


### PR DESCRIPTION
Performance comparison for one event:

Here:
```
❯ ipython time_fourier.py
[[-0.84497639  0.12606332 -0.41890738 ... -0.04808525 -0.29396779
  -0.9354359 ]
 [ 0.23389281 -0.00328971  1.44855959 ...  0.24069143 -2.06059856
  -0.30701159]]
439 µs ± 693 ns per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

On main:
```
❯ ipython time_fourier.py
[[-0.84497639  0.12606332 -0.41890738 ... -0.04808525 -0.29396779
  -0.9354359 ]
 [ 0.23389281 -0.00328971  1.44855959 ...  0.24069143 -2.06059856
  -0.30701159]]
940 µs ± 5.6 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```


Script:
```
from ctapipe_io_lst import LSTEventSource
from pathlib import Path
from traitlets.config import Config


test_data = Path('test_data').absolute()
test_r0_path = test_data / 'real/R0/20200218/LST-1.1.Run02008.0000_first50.fits.fz'
calib_version = "ctapipe-v0.17"
calib_path = test_data / 'real/monitoring/PixelCalibration/Cat-A/'
test_time_calib_path = calib_path / f'drs4_time_sampling_from_FF/20191124/{calib_version}/time_calibration.Run01625.0000.h5'
test_calib_path = calib_path / f'calibration/20200218/{calib_version}/calibration_filters_52.Run02006.0000.h5'
test_drs4_pedestal_path = calib_path / f'drs4_baseline/20200218/{calib_version}/drs4_pedestal.Run02005.0000.h5'


config = Config({
    'LSTEventSource': {
        'pointing_information': False,
        'trigger_information': False,
        'LSTR0Corrections': {
            'drs4_pedestal_path': test_drs4_pedestal_path,
            'drs4_time_calibration_path': test_time_calib_path,
            'calibration_path': test_calib_path,
        },
    },
})

source = LSTEventSource(
    input_url=test_r0_path,
    config=config,
)

with source:
    event = next(iter(source))

tel_id = 1


def compute_timeshift():
    return source.r0_r1_calibrator.get_drs4_time_correction(
        tel_id, source.r0_r1_calibrator.first_cap[tel_id],
        selected_gain_channel=event.r1.tel[tel_id].selected_gain_channel,
    )

print(compute_timeshift())

result = get_ipython().run_line_magic("timeit", "compute_timeshift()")
# orint"mean": result.average, "std": result.stdev})
```

Run with `ipython time_fourier.py`