### PR TITLE
Patch to allow calibration of un-calibrated 36-samples EvB data

### DIFF
--- a/src/ctapipe_io_lst/__init__.py
+++ b/src/ctapipe_io_lst/__init__.py
@@ -652,6 +652,22 @@ class LSTEventSource(EventSource):
                 self.fill_lst_event_container(array_event, zfits_event)
                 self.fill_trigger_info(array_event)
 
+            # Extend to 40 samples in case the EvB has recorded 36, to          
+            # allow DRS4 calibration (R1 will be clipped back to 36 samples     
+            # afterwards, as usual)
+            for c, fill_value in zip((array_event.r0, array_event.r1),
+                                     (self.data_stream.waveform_offset, 0)):
+                for tel_c in c.tel.values():
+                    for tel_c in c.tel.values():
+                        if tel_c.waveform is not None:
+                            if tel_c.waveform.shape[-1] == 36:
+                                pad_width = [(0, 0)] * tel_c.waveform.ndim
+                                pad_width[-1] = (3, 1)
+                                tel_c.waveform = np.pad(tel_c.waveform,
+                                                        pad_width,
+                                                        mode='constant',
+                                                        constant_values=fill_value)
+            
             self.fill_mon_container(array_event, zfits_event)
 
             # apply correction before the rest, so corrected time is used e.g. for pointing

--- a/src/ctapipe_io_lst/__init__.py
+++ b/src/ctapipe_io_lst/__init__.py
@@ -655,18 +655,19 @@ class LSTEventSource(EventSource):
             # Extend to 40 samples in case the EvB has recorded 36, to          
             # allow DRS4 calibration (R1 will be clipped back to 36 samples     
             # afterwards, as usual)
-            for c, fill_value in zip((array_event.r0, array_event.r1),
-                                     (self.data_stream.waveform_offset, 0)):
-                for tel_c in c.tel.values():
+            if self.data_stream is not None:
+                for c, fill_value in zip((array_event.r0, array_event.r1),
+                                         (self.data_stream.waveform_offset, 0)):
                     for tel_c in c.tel.values():
-                        if tel_c.waveform is not None:
-                            if tel_c.waveform.shape[-1] == 36:
-                                pad_width = [(0, 0)] * tel_c.waveform.ndim
-                                pad_width[-1] = (3, 1)
-                                tel_c.waveform = np.pad(tel_c.waveform,
-                                                        pad_width,
-                                                        mode='constant',
-                                                        constant_values=fill_value)
+                        for tel_c in c.tel.values():
+                            if tel_c.waveform is not None:
+                                if tel_c.waveform.shape[-1] == 36:
+                                    pad_width = [(0, 0)] * tel_c.waveform.ndim
+                                    pad_width[-1] = (3, 1)
+                                    tel_c.waveform = np.pad(tel_c.waveform,
+                                                            pad_width,
+                                                            mode='constant',
+                                                            constant_values=fill_value)
             
             self.fill_mon_container(array_event, zfits_event)
 


### PR DESCRIPTION
This just converts the waveforms to 40 samples before the calibration.
(R1, as usual, is later clipped back to 36)

Note, we hardly have any data (~30') taken like that... it is arguable whether this patch needs to be merged! 
Just leave it here in case it is needed.