### PR TITLE
Allow ctapipe 0.26, drop support for ctapipe < 0.23.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,21 +19,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: "3.10"
-            ctapipe-version: "0.19.3"
-            extra-reqs: "'numpy<2.0a0' 'scipy<1.14a0'"
-          - python-version: "3.11"
-            ctapipe-version: "0.21.2"
-            extra-reqs: "'numpy<2.0a0'"
-          - python-version: "3.11"
-            ctapipe-version: "0.22.0"
-            extra-reqs: "'numpy<2.0a0'"
           - python-version: "3.12"
             ctapipe-version: "0.23.2"
           - python-version: "3.12"
             ctapipe-version: "0.24.0"
           - python-version: "3.13"
             ctapipe-version: "0.25.0"
+          - python-version: "3.12"
+            ctapipe-version: "0.26.0"
 
     defaults:
       run:

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ python_requires = >=3.10
 zip_safe = False
 install_requires=
     astropy >=5.2,<8.0.0a0
-    ctapipe >=0.19.0,<0.26.0a0
+    ctapipe >=0.23.2,<0.27.0a0
     protozfits ~=2.6
     numpy >=1.20
     scipy


### PR DESCRIPTION
This just changes requirements and the CI config.

Should also adjust the code so that we do not perform the ctapipe version checks anymore.