### PR TITLE
Set absolute_factor and correct issue with relative_factor to allow ctapipe to perform the pixel charge correction

### DIFF
--- a/src/ctapipe_io_lst/calibration.py
+++ b/src/ctapipe_io_lst/calibration.py
@@ -341,17 +341,12 @@ class LSTR0Corrections(TelescopeComponent):
             else:
                 r1.waveform[invalid_pixels[r1.selected_gain_channel, PIXEL_INDEX]] = 0.0
 
-            # needed for charge scaling in ctapipe dl1 calib
-            if r1.selected_gain_channel is not None:
-                relative_factor = np.empty(N_PIXELS)
-                relative_factor[r1.selected_gain_channel == HIGH_GAIN] = self.calib_scale_high_gain.tel[tel_id]
-                relative_factor[r1.selected_gain_channel == LOW_GAIN] = self.calib_scale_low_gain.tel[tel_id]
-            else:
-                relative_factor = np.empty((N_GAINS, N_PIXELS))
-                relative_factor[HIGH_GAIN] = self.calib_scale_high_gain.tel[tel_id]
-                relative_factor[LOW_GAIN] = self.calib_scale_low_gain.tel[tel_id]
+            relative_factor = np.empty((N_GAINS, N_PIXELS))
+            relative_factor[HIGH_GAIN] = self.calib_scale_high_gain.tel[tel_id]
+            relative_factor[LOW_GAIN] = self.calib_scale_low_gain.tel[tel_id]
 
             event.calibration.tel[tel_id].dl1.relative_factor = relative_factor
+            event.calibration.tel[tel_id].dl1.absolute_factor = np.ones((N_GAINS, N_PIXELS))
 
     def fill_time_correction(self, event):
 

--- a/src/ctapipe_io_lst/calibration.py
+++ b/src/ctapipe_io_lst/calibration.py
@@ -341,12 +341,12 @@ class LSTR0Corrections(TelescopeComponent):
             else:
                 r1.waveform[invalid_pixels[r1.selected_gain_channel, PIXEL_INDEX]] = 0.0
 
-            relative_factor = np.empty((N_GAINS, N_PIXELS))
+            relative_factor = np.empty((N_GAINS, N_PIXELS), dtype=np.float32)
             relative_factor[HIGH_GAIN] = self.calib_scale_high_gain.tel[tel_id]
             relative_factor[LOW_GAIN] = self.calib_scale_low_gain.tel[tel_id]
 
             event.calibration.tel[tel_id].dl1.relative_factor = relative_factor
-            event.calibration.tel[tel_id].dl1.absolute_factor = np.ones((N_GAINS, N_PIXELS))
+            event.calibration.tel[tel_id].dl1.absolute_factor = np.ones((N_GAINS, N_PIXELS), dtype=np.float32)
 
     def fill_time_correction(self, event):
 


### PR DESCRIPTION
Fix #251 

Set the absolute_factor as :
`event.calibration.tel[tel_id].dl1.absolute_factor = np.ones((N_GAINS, N_PIXELS))`

Also fix an issue on relative_factor (was already fixed by this in lstchain : https://github.com/cta-observatory/cta-lstchain/blob/abc6d277ea275149950d733c61b431e2f06e90e8/lstchain/reco/r0_to_dl1.py#L543 )