### PR TITLE
Pixel time correction set to have median=0 for each event

### DIFF
--- a/src/ctapipe_io_lst/calibration.py
+++ b/src/ctapipe_io_lst/calibration.py
@@ -378,7 +378,7 @@ class LSTR0Corrections(TelescopeComponent):
                     # pixel_time_shift from lst.evt (or from r1 in the future)
                     # is (1, N_PIXELS), and contains the correction for the
                     # selected gain. On the other hand, time_shift in
-                    # event.calibration.tel[tel_id].dl1 is (2, N_PIXELS) no 
+                    # event.calibration.tel[tel_id].dl1 is (2, N_PIXELS) no
                     # matter whether the data is gain selected or not
                     time_shift = np.zeros((N_GAINS, N_PIXELS))
                     time_shift[r1.selected_gain_channel,

--- a/src/ctapipe_io_lst/calibration.py
+++ b/src/ctapipe_io_lst/calibration.py
@@ -4,6 +4,7 @@ import numpy as np
 import astropy.units as u
 from numba import njit
 import tables
+import logging
 from astropy.io import fits
 
 from ctapipe.core import TelescopeComponent
@@ -199,6 +200,9 @@ class LSTR0Corrections(TelescopeComponent):
             subarray=subarray, config=config, parent=parent, **kwargs
         )
 
+
+        self.log.setLevel(logging.INFO)
+
         self.mon_data = None
         self.last_readout_time = {}
         self.first_cap = {}
@@ -378,7 +382,11 @@ class LSTR0Corrections(TelescopeComponent):
                 # it later (in case e.g. a cat-A calibration file has
                 # been read in, and self.mon_data.tel[tel_id].calibration
                 # contains a non-zero time_correction value):
-                self.add_calibration_timeshift = False
+                if self.add_calibration_timeshift is True:
+                    self.log.info("NOTE: Pixel_time_shift provided by EVB in R1,"
+                                  " not adding time shift from calibration file"
+                    )
+                    self.add_calibration_timeshift = False
 
                 if r1.selected_gain_channel is None:
                     time_shift = lst.evt.pixel_time_shift # r1.pixel_time_shift

--- a/src/ctapipe_io_lst/calibration.py
+++ b/src/ctapipe_io_lst/calibration.py
@@ -372,6 +372,14 @@ class LSTR0Corrections(TelescopeComponent):
             # if r1.pixel_time_shift is not None:
             # Until pixel_time_shift is in R1CameraContainer... :
             if lst.evt.pixel_time_shift is not None:
+                # We assume that when pixel_time_shift is present
+                # in the input data (written out by EvB) it contains also
+                # inter-pixel time flatfielding. So we should not add
+                # it later (in case e.g. a cat-A calibration file has
+                # been read in, and self.mon_data.tel[tel_id].calibration
+                # contains a non-zero time_correction value):
+                self.add_calibration_timeshift = False
+
                 if r1.selected_gain_channel is None:
                     time_shift = lst.evt.pixel_time_shift # r1.pixel_time_shift
                 else:
@@ -385,7 +393,7 @@ class LSTR0Corrections(TelescopeComponent):
                                np.arange(N_PIXELS)] = lst.evt.pixel_time_shift[0]
                                # When pixel_time_shift is in r1:
                                # np.arange(N_PIXELS)] = r1.pixel_time_shift[0]
-
+                
 
             # Otherwise, try to get the correction from a drs4 calib file:
             else:

--- a/src/ctapipe_io_lst/calibration.py
+++ b/src/ctapipe_io_lst/calibration.py
@@ -406,30 +406,30 @@ class LSTR0Corrections(TelescopeComponent):
                     time_shift -= time_corr[r1.selected_gain_channel, PIXEL_INDEX].to_value(u.ns)
 
             # Change time_shift so that for each event the median correction
-            # for all pixels is zero. In this way we modify as little as 
-            # possible the times, as compared to their "raw" sample values in 
+            # for all pixels is zero. In this way we modify as little as
+            # possible the times, as compared to their "raw" sample values in
             # the readout waveforms. This is convenient to keep the information
             # of where the pulses were actually located within the readout
-            # window. NOTE: this means that the absolute *average* arrival 
-            # time of the events (relative to the trigger time) is a bit 
-            # less precise, because there are correlations in the DRS4 time 
-            # corrections of the bulk of the pixels. By correcting to the 
+            # window. NOTE: this means that the absolute *average* arrival
+            # time of the events (relative to the trigger time) is a bit
+            # less precise, because there are correlations in the DRS4 time
+            # corrections of the bulk of the pixels. By correcting to the
             # event median, we do not subtract these (quasi-) global shifts
             # in time of the bulk of the camera. This is visible also as an
-            # increase in the std dev of each pixel's time in FF events 
-            # (relative to the situation without the "median-event-t 
+            # increase in the std dev of each pixel's time in FF events
+            # (relative to the situation without the "median-event-t
             # correction". This increase is of a few percent, and is pixel
-            # dependent (some pixels have a DRS4 time correction more 
+            # dependent (some pixels have a DRS4 time correction more
             # correlated to the rest than others), so with this approach one
             # can also distinguish 3 populations of pixels with std dev of
-            # FF times between 1.02 ans 1.10 ns. What really matters, which 
+            # FF times between 1.02 ans 1.10 ns. What really matters, which
             # is the relative precision of the timing among pixels, is of
             # course not affected by this correction, since it is a global
             # shift per event.
             #
             if r1.selected_gain_channel is None:
                 time_shift = time_shift - np.nanmedian(time_shift)
-            else: 
+            else:
                 tmedian = np.nanmedian(time_shift[r1.selected_gain_channel,
                                                   PIXEL_INDEX])
                 time_shift = time_shift - tmedian

--- a/src/ctapipe_io_lst/calibration.py
+++ b/src/ctapipe_io_lst/calibration.py
@@ -375,10 +375,17 @@ class LSTR0Corrections(TelescopeComponent):
                 if r1.selected_gain_channel is None:
                     time_shift = lst.evt.pixel_time_shift # r1.pixel_time_shift
                 else:
+                    # pixel_time_shift from lst.evt (or from r1 in the future)
+                    # is (1, N_PIXELS), and contains the correction for the
+                    # selected gain. On the other hand, time_shift in
+                    # event.calibration.tel[tel_id].dl1 is (2, N_PIXELS) no 
+                    # matter whether the data is gain selected or not
                     time_shift = np.zeros((N_GAINS, N_PIXELS))
                     time_shift[r1.selected_gain_channel,
-                               # np.arange(N_PIXELS)] = r1.pixel_time_shift[0]
                                np.arange(N_PIXELS)] = lst.evt.pixel_time_shift[0]
+                               # When pixel_time_shift is in r1:
+                               # np.arange(N_PIXELS)] = r1.pixel_time_shift[0]
+
 
             # Otherwise, try to get the correction from a drs4 calib file:
             else:
@@ -397,6 +404,37 @@ class LSTR0Corrections(TelescopeComponent):
                     time_shift -= time_corr.to_value(u.ns)
                 else:
                     time_shift -= time_corr[r1.selected_gain_channel, PIXEL_INDEX].to_value(u.ns)
+
+            # Change time_shift so that for each event the median correction
+            # for all pixels is zero. In this way we modify as little as 
+            # possible the times, as compared to their "raw" sample values in 
+            # the readout waveforms. This is convenient to keep the information
+            # of where the pulses were actually located within the readout
+            # window. NOTE: this means that the absolute *average* arrival 
+            # time of the events (relative to the trigger time) is a bit 
+            # less precise, because there are correlations in the DRS4 time 
+            # corrections of the bulk of the pixels. By correcting to the 
+            # event median, we do not subtract these (quasi-) global shifts
+            # in time of the bulk of the camera. This is visible also as an
+            # increase in the std dev of each pixel's time in FF events 
+            # (relative to the situation without the "median-event-t 
+            # correction". This increase is of a few percent, and is pixel
+            # dependent (some pixels have a DRS4 time correction more 
+            # correlated to the rest than others), so with this approach one
+            # can also distinguish 3 populations of pixels with std dev of
+            # FF times between 1.02 ans 1.10 ns. What really matters, which 
+            # is the relative precision of the timing among pixels, is of
+            # course not affected by this correction, since it is a global
+            # shift per event.
+            #
+            if r1.selected_gain_channel is None:
+                time_shift = time_shift - np.nanmedian(time_shift)
+            else: 
+                tmedian = np.nanmedian(time_shift[r1.selected_gain_channel,
+                                                  PIXEL_INDEX])
+                time_shift = time_shift - tmedian
+                # Keep as zero for non-selected gain:
+                time_shift[~r1.selected_gain_channel, PIXEL_INDEX] = 0
 
             event.calibration.tel[tel_id].dl1.time_shift = time_shift
 

--- a/src/ctapipe_io_lst/tests/test_lsteventsource.py
+++ b/src/ctapipe_io_lst/tests/test_lsteventsource.py
@@ -444,7 +444,11 @@ def test_evb_calibrated_data():
         read_events = 0
         for e in source:
             read_events += 1
-            assert np.all(e.calibration.tel[1].dl1.time_shift != 0)
+            time_shift = e.calibration.tel[1].dl1.time_shift
+            sg = e.r1.tel[1].selected_gain_channel
+            # Check that non-zero and different values are present for
+            # the selecetd channel:
+            assert np.std(time_shift[sg, np.arange(time_shift.shape[1])]) > 0
 
         assert read_events == 200
 

--- a/src/ctapipe_io_lst/tests/test_lsteventsource.py
+++ b/src/ctapipe_io_lst/tests/test_lsteventsource.py
@@ -11,7 +11,7 @@ import tables
 from ctapipe.containers import CoordinateFrameType, EventType, PointingMode
 from ctapipe.calib.camera.gainselection import ThresholdGainSelector
 
-from ctapipe_io_lst.constants import LST1_LOCATION, N_GAINS, N_PIXELS_MODULE, N_SAMPLES, N_PIXELS
+from ctapipe_io_lst.constants import LST1_LOCATION, N_GAINS, N_PIXELS_MODULE, N_SAMPLES, N_PIXELS, PIXEL_INDEX
 from ctapipe_io_lst import CTAPIPE_GE_0_20, CTAPIPE_GE_0_21, TriggerBits, PixelStatus
 
 test_data = Path(os.getenv('LSTCHAIN_TEST_DATA', 'test_data')).absolute()
@@ -428,7 +428,8 @@ def test_time_correction(timeshift):
 
 def test_evb_calibrated_data():
     from ctapipe_io_lst import LSTEventSource
-    input_url = test_data / 'real/R0/20231219/LST-1.1.Run16255.0000_first50.fits.fz'
+    input_urls = ['real/R0/20231219/LST-1.1.Run16255.0000_first50.fits.fz',
+                  'real/R0/20250326/LST-1.1.Run20527.0000_first50.fits.fz']
 
     config = {
         'LSTEventSource': {
@@ -440,17 +441,22 @@ def test_evb_calibrated_data():
         },
     }
 
-    with LSTEventSource(input_url, config=Config(config)) as source:
-        read_events = 0
-        for e in source:
-            read_events += 1
-            time_shift = e.calibration.tel[1].dl1.time_shift
-            sg = e.r1.tel[1].selected_gain_channel
-            # Check that non-zero and different values are present for
-            # the selected channel(s):
-            assert np.std(time_shift) > 0
+    for input_url in input_urls:
+        input_url = test_data / input_url
+        with LSTEventSource(input_url, config=Config(config)) as source:
+            read_events = 0
+            for e in source:
+                read_events += 1
+                time_shift = e.calibration.tel[1].dl1.time_shift
+                sg = e.r1.tel[1].selected_gain_channel
+                # Check that non-zero and different values are present for
+                # the selected channel(s):
+                if sg is not None:
+                    assert np.std(time_shift[sg, PIXEL_INDEX]) > 0
+                else:
+                    assert np.std(time_shift) > 0
 
-        assert read_events == 200
+            assert read_events == 200
 
 
 def test_arbitrary_filename(tmp_path):

--- a/src/ctapipe_io_lst/tests/test_lsteventsource.py
+++ b/src/ctapipe_io_lst/tests/test_lsteventsource.py
@@ -429,9 +429,10 @@ def test_time_correction(timeshift):
 def test_evb_calibrated_data():
     from ctapipe_io_lst import LSTEventSource
     input_urls = ['real/R0/20231219/LST-1.1.Run16255.0000_first50.fits.fz',
-                  'real/R0/20250326/LST-1.1.Run20527.0000_first50.fits.fz']
-    drs4calib = [str(test_time_calib_path), None]
-    calib = [str(test_calib_path), None]
+                  'real/R0/20250326/LST-1.1.Run20527.0000_first50.fits.fz',
+                  'real/R0/20260521/LST-1.1.Run24235.0010_first50.fits.fz']
+    drs4calib = [str(test_time_calib_path), None, None]
+    calib = [str(test_calib_path), None, None]
 
     for input_url, dcal, cal in zip(input_urls, drs4calib, calib):
         input_url = test_data / input_url

--- a/src/ctapipe_io_lst/tests/test_lsteventsource.py
+++ b/src/ctapipe_io_lst/tests/test_lsteventsource.py
@@ -430,19 +430,21 @@ def test_evb_calibrated_data():
     from ctapipe_io_lst import LSTEventSource
     input_urls = ['real/R0/20231219/LST-1.1.Run16255.0000_first50.fits.fz',
                   'real/R0/20250326/LST-1.1.Run20527.0000_first50.fits.fz']
+    drs4calib = [str(test_time_calib_path), None]
+    calib = [str(test_calib_path), None]
 
-    config = {
-        'LSTEventSource': {
-            "pointing_information": False,
-            'LSTR0Corrections': {
-                'drs4_time_calibration_path': str(test_time_calib_path),
-                'calibration_path': str(test_calib_path),
-            },
-        },
-    }
-
-    for input_url in input_urls:
+    for input_url, dcal, cal in zip(input_urls, drs4calib, calib):
         input_url = test_data / input_url
+        config = {
+            'LSTEventSource': {
+                "pointing_information": False,
+                'LSTR0Corrections': {
+                    'drs4_time_calibration_path': dcal,
+                    'calibration_path': cal,
+                },
+            },
+        }
+
         with LSTEventSource(input_url, config=Config(config)) as source:
             read_events = 0
             for e in source:

--- a/src/ctapipe_io_lst/tests/test_lsteventsource.py
+++ b/src/ctapipe_io_lst/tests/test_lsteventsource.py
@@ -448,10 +448,7 @@ def test_evb_calibrated_data():
             sg = e.r1.tel[1].selected_gain_channel
             # Check that non-zero and different values are present for
             # the selected channel(s):
-            if sg is None:
-                assert np.std(time_shift) > 0
-            else:
-                assert np.std(time_shift[sg, np.arange(time_shift.shape[1])]) > 0
+            assert np.std(time_shift) > 0
 
         assert read_events == 200
 

--- a/src/ctapipe_io_lst/tests/test_lsteventsource.py
+++ b/src/ctapipe_io_lst/tests/test_lsteventsource.py
@@ -447,8 +447,11 @@ def test_evb_calibrated_data():
             time_shift = e.calibration.tel[1].dl1.time_shift
             sg = e.r1.tel[1].selected_gain_channel
             # Check that non-zero and different values are present for
-            # the selecetd channel:
-            assert np.std(time_shift[sg, np.arange(time_shift.shape[1])]) > 0
+            # the selected channel(s):
+            if sg is None:
+                assert np.std(time_shift) > 0
+            else:
+                assert np.std(time_shift[sg, np.arange(time_shift.shape[1])]) > 0
 
         assert read_events == 200
 


### PR DESCRIPTION
The correction applied to pixel times (for fully EvB_calibrated data) is now such that the median correction per event (for the full camera) is zero. In this way we modify as little as possible the times relative to the raw values, and they will still indicate (roughly) where the pulse is within the readout window. Since the corrections are correlated for many pixels, this means that the corrected times have now slightly larger fluctuations as "absolute times" w.r.t. the trigger moment. The std dev of the FF pulse times of any given pixel is a bit larger. The relative times among pixels (=what is relevant for the analysis) is of course unaffected. This can be modified later in Cat-B if desired (to recover the previous behaviour), but there is no actual advantage of doing so performance-wise.